### PR TITLE
Trade sim: optional destination the ship makes for instead of home

### DIFF
--- a/src/components/ship_simulator.rs
+++ b/src/components/ship_simulator.rs
@@ -491,9 +491,9 @@ pub fn ShipSimulator(
     let home_uwp = RwSignal::new("A788899-A".to_string());
     let home_zone = RwSignal::new(ZoneClassification::Green);
 
-    // Optional cruise destination (Piracy only). Blank by default → the ship
-    // returns to the hideout as before; set a world and the cruise makes for
-    // it to finish instead.
+    // Optional destination (both modes). Blank by default → the ship makes a
+    // round trip back home (the trade run) or to the hideout (the cruise); set
+    // a world and it makes for that world to finish instead.
     let dest_name = RwSignal::new(String::new());
     let dest_sector = RwSignal::new(String::new());
     let dest_coords = RwSignal::new(None::<(i32, i32)>);
@@ -1205,18 +1205,18 @@ fn SimForm(
                 </div>
             </fieldset>
 
-            {move || is_piracy().then(|| view! {
-                <fieldset class="sim-fieldset">
-                    <legend>"Destination (optional)"</legend>
-                    <WorldSearch
-                        label="Destination".to_string()
-                        name=dest_name
-                        uwp=dest_uwp
-                        coords=dest_coords
-                        zone=dest_zone
-                        sector=dest_sector
-                        show_uwp=false
-                    />
+            <fieldset class="sim-fieldset">
+                <legend>"Destination (optional)"</legend>
+                <WorldSearch
+                    label="Destination".to_string()
+                    name=dest_name
+                    uwp=dest_uwp
+                    coords=dest_coords
+                    zone=dest_zone
+                    sector=dest_sector
+                    show_uwp=false
+                />
+                {move || is_piracy().then(|| view! {
                     <label class="sim-haven-toggle">
                         <input
                             type="checkbox"
@@ -1225,54 +1225,58 @@ fn SimForm(
                         />
                         <span>"Haven — safe port to fence, bank prizes & lie low"</span>
                     </label>
-                    <div class="sim-home-summary">
-                        {move || {
-                            let coords = dest_coords.get();
-                            let sector = dest_sector.get();
-                            let uwp = dest_uwp.get();
-                            let zone = dest_zone.get();
-                            if let Some((hx, hy)) = coords && !sector.is_empty() && uwp.len() == 9 {
-                                view! {
-                                    <div class="sim-home-detail">
-                                        <div>
-                                            <strong>{sector}</strong>
-                                            " · hex "
-                                            <code>{format!("{:02}{:02}", hx, hy)}</code>
-                                            " · UWP "
-                                            <code>{uwp}</code>
-                                        </div>
-                                        <div>
-                                            <span class={format!("sim-zone-{}", zone.to_string().to_lowercase())}>
-                                                {zone.to_string()}
-                                            </span>
-                                            " zone"
-                                            <button
-                                                type="button"
-                                                class="sim-dest-clear"
-                                                on:click=move |_| {
-                                                    dest_name.set(String::new());
-                                                    dest_sector.set(String::new());
-                                                    dest_coords.set(None);
-                                                    dest_uwp.set(String::new());
-                                                    dest_zone.set(ZoneClassification::Green);
-                                                }
-                                            >
-                                                "Clear"
-                                            </button>
-                                        </div>
+                })}
+                <div class="sim-home-summary">
+                    {move || {
+                        let coords = dest_coords.get();
+                        let sector = dest_sector.get();
+                        let uwp = dest_uwp.get();
+                        let zone = dest_zone.get();
+                        if let Some((hx, hy)) = coords && !sector.is_empty() && uwp.len() == 9 {
+                            view! {
+                                <div class="sim-home-detail">
+                                    <div>
+                                        <strong>{sector}</strong>
+                                        " · hex "
+                                        <code>{format!("{:02}{:02}", hx, hy)}</code>
+                                        " · UWP "
+                                        <code>{uwp}</code>
                                     </div>
-                                }.into_any()
-                            } else {
-                                view! {
-                                    <div class="sim-home-detail sim-home-empty">
+                                    <div>
+                                        <span class={format!("sim-zone-{}", zone.to_string().to_lowercase())}>
+                                            {zone.to_string()}
+                                        </span>
+                                        " zone"
+                                        <button
+                                            type="button"
+                                            class="sim-dest-clear"
+                                            on:click=move |_| {
+                                                dest_name.set(String::new());
+                                                dest_sector.set(String::new());
+                                                dest_coords.set(None);
+                                                dest_uwp.set(String::new());
+                                                dest_zone.set(ZoneClassification::Green);
+                                            }
+                                        >
+                                            "Clear"
+                                        </button>
+                                    </div>
+                                </div>
+                            }.into_any()
+                        } else {
+                            view! {
+                                <div class="sim-home-detail sim-home-empty">
+                                    {if is_piracy() {
                                         "Leave blank to return to the hideout, or search for a world to make for."
-                                    </div>
-                                }.into_any()
-                            }
-                        }}
-                    </div>
-                </fieldset>
-            })}
+                                    } else {
+                                        "Leave blank for a round trip home, or search for a world to make for."
+                                    }}
+                                </div>
+                            }.into_any()
+                        }
+                    }}
+                </div>
+            </fieldset>
 
             <fieldset class="sim-fieldset">
                 <legend>"Voyage"</legend>
@@ -1982,20 +1986,26 @@ fn SimSummary(
                                     </span>
                                 </div>
                             })}
-                            {(!is_piracy && !marooned).then(|| view! {
-                                <div class="sim-summary-row">
-                                    <span class="sim-summary-label">"Returned home?"</span>
-                                    <span class="sim-summary-value">
-                                        {if r.returned_home { "Yes" } else { "No" }}
-                                    </span>
-                                </div>
-                            })}
-                            {(is_piracy && !marooned)
+                            // With a destination set (either mode), the trip makes for it and
+                            // `returned_home` reports whether it reached that destination.
+                            {(!marooned)
                                 .then(|| last_params.get().and_then(|p| p.destination))
                                 .flatten()
                                 .map(|dest| view! {
                                     <div class="sim-summary-row">
                                         <span class="sim-summary-label">{format!("Reached {}?", dest.name)}</span>
+                                        <span class="sim-summary-value">
+                                            {if r.returned_home { "Yes" } else { "No" }}
+                                        </span>
+                                    </div>
+                                })}
+                            // No destination: a trade round trip reports whether it made it home.
+                            {(!is_piracy
+                                && !marooned
+                                && last_params.get().and_then(|p| p.destination).is_none())
+                                .then(|| view! {
+                                    <div class="sim-summary-row">
+                                        <span class="sim-summary-label">"Returned home?"</span>
                                         <span class="sim-summary-value">
                                             {if r.returned_home { "Yes" } else { "No" }}
                                         </span>

--- a/src/simulator/executor.rs
+++ b/src/simulator/executor.rs
@@ -676,7 +676,7 @@ pub async fn run_simulation(
 
             // Build the routing context (current_date may have advanced).
             let base_ctx = RouteContext {
-                home: &params.home_world,
+                terminal: terminal_ref,
                 current_date,
                 start_date: params.start_date,
                 target_date: params.target_completion_date,
@@ -916,12 +916,14 @@ pub async fn run_simulation(
             }
         }
 
-        // (4) End-of-trip detection. We're home and have actually travelled.
-        // Price and sell whatever's still in the hold (anything we bought on
-        // the last leg expecting to sell at home), then break out of the
-        // loop. Without this, profitable cargo bought for the home leg sits
-        // unrealized and the trip P&L is skewed by hundreds of kCr.
-        let at_home = jumps_taken > 0 && worldref_same_hex(&current_ref, &params.home_world);
+        // (4) End-of-trip detection. We've reached the terminal — the
+        // destination when one is set, else home — and have actually
+        // travelled. Price and sell whatever's still in the hold (anything we
+        // bought on the last leg expecting to sell at the finish), then break
+        // out of the loop. Without this, profitable cargo bought for the final
+        // leg sits unrealized and the trip P&L is skewed by hundreds of kCr.
+        // The planner's first-half exclusion keeps us from arriving here early.
+        let at_terminal = jumps_taken > 0 && worldref_same_hex(&current_ref, terminal_ref);
 
         // (5) Generate this port's market and price to buy locally.
         let trade_table = TradeTable::global();
@@ -996,11 +998,11 @@ pub async fn run_simulation(
             }
         }
 
-        // (5b) End-of-trip settlement. If we're back home, realize the sale
-        // revenue from the cargo we just priced and break. We pass empty
-        // `buy_goods` and `None` passengers because the next-jump prep
-        // (steps 7-10) is skipped when at home.
-        if at_home {
+        // (5b) End-of-trip settlement. If we've reached the terminal, realize
+        // the sale revenue from the cargo we just priced and break. We pass
+        // empty `buy_goods` and `None` passengers because the next-jump prep
+        // (steps 7-10) is skipped at the finish.
+        if at_terminal {
             // Sale proceeds were already applied to `budget` per-good in
             // step (5); we just need to flush the manifest mutations
             // (clear sold cargo) without double-counting revenue.
@@ -1032,7 +1034,7 @@ pub async fn run_simulation(
         }
 
         let ctx = RouteContext {
-            home: &params.home_world,
+            terminal: terminal_ref,
             current_date,
             start_date: params.start_date,
             target_date: params.target_completion_date,

--- a/src/simulator/executor.rs
+++ b/src/simulator/executor.rs
@@ -154,9 +154,14 @@ pub async fn run_simulation(
         },
     );
 
-    // The world the pirate cruise makes for to *finish*: the destination when
-    // one is set, else the hideout (a round trip). Independent of haven status.
+    // The world the trip makes for to *finish*: the destination when one is
+    // set, else home/the hideout (a round trip). Independent of haven status.
     let terminal_ref: &WorldRef = params.destination.as_ref().unwrap_or(&params.home_world);
+    // A distinct destination makes this a one-way "direct run": the trade
+    // planner steers for the terminal from the start instead of exploring then
+    // looping home. Only consumed by the merchant planner (`route::pick_next`);
+    // the pirate planner has its own terminal handling.
+    let direct_run = params.destination.is_some();
 
     // The pirate's havens — safe ports where it fences the whole hold at law 0,
     // banks prizes, and lies low. The home world and/or the destination, per
@@ -683,6 +688,7 @@ pub async fn run_simulation(
                 jump: params.ship.jump_rating as i32,
                 fuel_cost_per_parsec: params.fuel_cost_per_parsec,
                 history: &history,
+                direct_run,
             };
             let upcoming_upkeep =
                 params.ship.monthly_expenses() + params.ship.crew_life_support_per_jump();
@@ -1041,6 +1047,7 @@ pub async fn run_simulation(
             jump: params.ship.jump_rating as i32,
             fuel_cost_per_parsec: params.fuel_cost_per_parsec,
             history: &history,
+            direct_run,
         };
         let next = match route::pick_next(&candidates, &market, &ctx) {
             Some(n) => n,

--- a/src/simulator/executor.rs
+++ b/src/simulator/executor.rs
@@ -24,7 +24,7 @@ use crate::simulator::types::{
     Action, ActTier, Date, EncounterOutcome, EncounterType, PreyPassedReason, Prize,
     SimulationMode, SimulationParams, SimulationResult, SimulationStep, WorldRef,
 };
-use crate::simulator::world_fetch::{FetchError, WorldCache};
+use crate::simulator::world_fetch::{self, FetchError, WorldCache};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use crate::systems::world::World;
@@ -154,9 +154,27 @@ pub async fn run_simulation(
         },
     );
 
-    // The world the trip makes for to *finish*: the destination when one is
-    // set, else home/the hideout (a round trip). Independent of haven status.
-    let terminal_ref: &WorldRef = params.destination.as_ref().unwrap_or(&params.home_world);
+    // Resolve home and destination to **absolute** hex coordinates — the
+    // simulator's canonical space for all routing math, so home, destination,
+    // and candidates can sit in different sectors. Two `/api/coordinates`
+    // lookups at most, cached in the WorldCache.
+    let home_abs = world_fetch::absolute_hex(
+        cache.sector_offset(&params.home_world.sector).await?,
+        (params.home_world.hex_x, params.home_world.hex_y),
+    );
+    let dest_abs: Option<(i32, i32)> = match params.destination.as_ref() {
+        Some(d) => Some(world_fetch::absolute_hex(
+            cache.sector_offset(&d.sector).await?,
+            (d.hex_x, d.hex_y),
+        )),
+        None => None,
+    };
+    let mut current_abs = home_abs;
+
+    // The absolute hex the trip makes for to *finish*: the destination when
+    // one is set, else home/the hideout (a round trip). Independent of haven
+    // status.
+    let terminal_abs = dest_abs.unwrap_or(home_abs);
     // A distinct destination makes this a one-way "direct run": the trade
     // planner steers for the terminal from the start instead of exploring then
     // looping home. Only consumed by the merchant planner (`route::pick_next`);
@@ -166,19 +184,18 @@ pub async fn run_simulation(
     // The pirate's havens — safe ports where it fences the whole hold at law 0,
     // banks prizes, and lies low. The home world and/or the destination, per
     // their haven flags. Usually just the home world (the hideout).
-    let havens: Vec<&WorldRef> = {
-        let mut v: Vec<&WorldRef> = Vec::new();
+    let haven_abs: Vec<(i32, i32)> = {
+        let mut v: Vec<(i32, i32)> = Vec::new();
         if params.home_is_haven {
-            v.push(&params.home_world);
+            v.push(home_abs);
         }
         if params.destination_is_haven
-            && let Some(dest) = params.destination.as_ref()
+            && let Some(da) = dest_abs
         {
-            v.push(dest);
+            v.push(da);
         }
         v
     };
-    let haven_hexes: Vec<(i32, i32)> = havens.iter().map(|w| (w.hex_x, w.hex_y)).collect();
 
     // === main loop =======================================================
     loop {
@@ -293,9 +310,7 @@ pub async fn run_simulation(
             }
 
             // Are we sitting at one of our havens (a safe port)?
-            let at_haven = havens
-                .iter()
-                .any(|h| worldref_same_hex(&current_ref, h));
+            let at_haven = haven_abs.contains(&current_abs);
 
             // Put in at a haven after travelling: a drop-off. Fence the hold
             // (best odds — a haven counts as law 0) and bank any prizes, which
@@ -340,8 +355,7 @@ pub async fn run_simulation(
             // the hideout. Once we're in the head-home window, arriving here
             // ends the cruise. (With no destination, this coincides with the
             // hideout drop-off above, preserving the round-trip behaviour.)
-            let at_terminal =
-                jumps_taken > 0 && worldref_same_hex(&current_ref, terminal_ref);
+            let at_terminal = jumps_taken > 0 && current_abs == terminal_abs;
             if at_terminal {
                 let total =
                     params.start_date.days_until(params.target_completion_date) as f64;
@@ -681,7 +695,8 @@ pub async fn run_simulation(
 
             // Build the routing context (current_date may have advanced).
             let base_ctx = RouteContext {
-                terminal: terminal_ref,
+                terminal_abs,
+                current_abs,
                 current_date,
                 start_date: params.start_date,
                 target_date: params.target_completion_date,
@@ -708,8 +723,8 @@ pub async fn run_simulation(
                 ship_weapons: params.ship.weapons,
                 prize_run,
                 lying_low,
-                terminal_hex: (terminal_ref.hex_x, terminal_ref.hex_y),
-                haven_hexes: haven_hexes.clone(),
+                terminal_abs,
+                haven_abs: haven_abs.clone(),
             };
             if proute::route_mode(&pctx_pre) == proute::RouteMode::FenceRun
                 && plundered_value > 0
@@ -821,8 +836,8 @@ pub async fn run_simulation(
                 ship_weapons: params.ship.weapons,
                 prize_run,
                 lying_low,
-                terminal_hex: (terminal_ref.hex_x, terminal_ref.hex_y),
-                haven_hexes: haven_hexes.clone(),
+                terminal_abs,
+                haven_abs: haven_abs.clone(),
             };
             let mode = proute::route_mode(&pctx_route);
             let next = match proute::pick_next_pirate(&candidates, mode, &pctx_route) {
@@ -841,7 +856,7 @@ pub async fn run_simulation(
                     break;
                 }
             };
-            let next_ref = world_ref_for(&next.world, &current_ref.sector);
+            let next_ref = world_ref_for(&next.world, &next.sector);
 
             // (P7) Pay fuel and jump.
             let fuel_for_jump = (next.distance as i64) * params.fuel_cost_per_parsec;
@@ -866,6 +881,7 @@ pub async fn run_simulation(
             }
             current_world = next.world.clone();
             current_ref = next_ref.clone();
+            current_abs = next.abs;
             current_allegiance = next.allegiance.clone();
             current_date = current_date.add_days(DAYS_PER_JUMP);
             days_since_payment += DAYS_PER_JUMP;
@@ -929,7 +945,7 @@ pub async fn run_simulation(
         // out of the loop. Without this, profitable cargo bought for the final
         // leg sits unrealized and the trip P&L is skewed by hundreds of kCr.
         // The planner's first-half exclusion keeps us from arriving here early.
-        let at_terminal = jumps_taken > 0 && worldref_same_hex(&current_ref, terminal_ref);
+        let at_terminal = jumps_taken > 0 && current_abs == terminal_abs;
 
         // (5) Generate this port's market and price to buy locally.
         let trade_table = TradeTable::global();
@@ -1040,7 +1056,8 @@ pub async fn run_simulation(
         }
 
         let ctx = RouteContext {
-            terminal: terminal_ref,
+            terminal_abs,
+            current_abs,
             current_date,
             start_date: params.start_date,
             target_date: params.target_completion_date,
@@ -1065,7 +1082,7 @@ pub async fn run_simulation(
                 break;
             }
         };
-        let next_ref = world_ref_for(&next.world, &current_ref.sector);
+        let next_ref = world_ref_for(&next.world, &next.sector);
 
         // (7) PAX FIRST: each passenger reserves a personal-cargo
         // allotment (1 ton high, 0.1 medium, 0.01 basic, 0 low), so we
@@ -1276,6 +1293,7 @@ pub async fn run_simulation(
         }
         current_world = next.world.clone();
         current_ref = next_ref.clone();
+        current_abs = next.abs;
         current_allegiance = next.allegiance.clone();
         // Jump time only — the port stay was already added at step (2b).
         current_date = current_date.add_days(DAYS_PER_JUMP);
@@ -1575,9 +1593,9 @@ fn emit(
     });
 }
 
-/// Build a `WorldRef` for one of the executor's neighbouring worlds.
-/// In v1 the simulator stays in-sector so we propagate the current
-/// sector unchanged.
+/// Build a `WorldRef` for one of the executor's neighbouring worlds,
+/// stamped with the candidate's **own** sector — which may differ from
+/// the current location's when a jump crosses a sector boundary.
 fn world_ref_for(world: &World, sector: &str) -> WorldRef {
     let (hex_x, hex_y) = world.coordinates.unwrap_or((0, 0));
     WorldRef {
@@ -1588,13 +1606,6 @@ fn world_ref_for(world: &World, sector: &str) -> WorldRef {
         hex_y,
         zone: world.travel_zone,
     }
-}
-
-/// Two `WorldRef`s point at the same world iff they share sector and
-/// hex. We don't compare names or UWPs because either could differ
-/// between the user's input and what TravellerMap returned.
-fn worldref_same_hex(a: &WorldRef, b: &WorldRef) -> bool {
-    a.sector == b.sector && a.hex_x == b.hex_x && a.hex_y == b.hex_y
 }
 
 /// Quick upper-bound estimate of life-support + stateroom costs we
@@ -1735,17 +1746,6 @@ mod tests {
             hex_y: 10,
             zone: ZoneClassification::Green,
         }
-    }
-
-    #[test]
-    fn worldref_same_hex_compares_sector_and_hex() {
-        let a = dummy_home();
-        let mut b = a.clone();
-        b.name = "Different".to_string();
-        b.uwp = "X000000-0".to_string();
-        assert!(worldref_same_hex(&a, &b));
-        b.hex_x = 11;
-        assert!(!worldref_same_hex(&a, &b));
     }
 
     #[test]
@@ -1900,6 +1900,96 @@ mod tests {
         eprintln!("Steps: {}", step_count);
         eprintln!("Result: {:#?}", result);
         assert!(result.jumps > 0, "should have made at least one jump");
+    }
+
+    /// Cross-sector smoke: Drinax (Trojan Reach 2223) to Regina (Spinward
+    /// Marches 1910) with jump 4 — ~54 parsecs, crossing the sector seam.
+    /// Exercises the jumpworlds candidate fetch, absolute-coordinate
+    /// routing, and the direct-run destination pull end to end. Ignored
+    /// because it requires network (one jumpworlds call per jump).
+    #[tokio::test]
+    #[ignore]
+    async fn simulator_smoke_drinax_to_regina() {
+        let _ = env_logger::Builder::from_default_env()
+            .is_test(true)
+            .try_init();
+        let params = SimulationParams {
+            ship: Ship {
+                name: "Harrier".into(),
+                captain_name: String::new(),
+                broker_skill: 2,
+                steward_skill: 1,
+                leadership_skill: 1,
+                weapons: 2,
+                thrust: 0,
+                cargo_capacity: 80,
+                crew_staterooms: 4,
+                passenger_staterooms: 6,
+                low_berths: 4,
+                jump_rating: 4,
+                crew_size: 4,
+                mortgage_per_period: 0,
+                maintenance_per_period: 30_000,
+                salary_per_period: 12_000,
+            },
+            fuel_cost_per_parsec: 5_000,
+            crew_profit_share: 0.1,
+            starting_budget: 2_000_000,
+            home_world: WorldRef {
+                name: "Drinax".to_string(),
+                uwp: "A43645A-E".to_string(),
+                sector: "Trojan Reach".to_string(),
+                hex_x: 22,
+                hex_y: 23,
+                zone: ZoneClassification::Green,
+            },
+            destination: Some(WorldRef {
+                name: "Regina".to_string(),
+                uwp: "A788899-A".to_string(),
+                sector: "Spinward Marches".to_string(),
+                hex_x: 19,
+                hex_y: 10,
+                zone: ZoneClassification::Green,
+            }),
+            home_is_haven: true,
+            destination_is_haven: false,
+            // ~54 parsecs at J-4 is ~15 jumps; every visit costs 14+ days
+            // (port + jump), and a single Government Complication incident
+            // can eat 2d6 *weeks*, so a realistic worst case runs 500+
+            // days. The strict-progress filter steers from the first hop
+            // regardless of the target date; the generous target just keeps
+            // the overflow-abort guard out of the picture.
+            start_date: crate::simulator::types::Date::new(1, 1105),
+            target_completion_date: crate::simulator::types::Date::new(300, 1106),
+            illegal_goods: false,
+            planetary_broker_skill: 2,
+            mode: SimulationMode::Trade,
+            attitude: Attitude::Hungry,
+            starting_reputation: 0.0,
+            rng_seed: None,
+        };
+        let mut cache = WorldCache::new();
+        let result = run_simulation(params, &mut cache, |s| {
+            if let Action::Arrive { distance, .. } = &s.action {
+                eprintln!(
+                    "[{}] arrived {} ({}, {:02}{:02}) after J-{}",
+                    s.date.format(),
+                    s.location.name,
+                    s.location.sector,
+                    s.location.hex_x,
+                    s.location.hex_y,
+                    distance
+                );
+            }
+        })
+        .await
+        .expect("simulation should complete");
+        eprintln!("Result: jumps={} returned_home={}", result.jumps, result.returned_home);
+        assert!(
+            result.returned_home,
+            "ship should reach Regina (marooned={} reason={:?})",
+            result.marooned, result.marooned_reason
+        );
     }
 
     /// Marooning smoke: starve the ship of cash and confirm it terminates

--- a/src/simulator/piracy/route.rs
+++ b/src/simulator/piracy/route.rs
@@ -40,15 +40,16 @@ pub struct PirateRouteContext<'a> {
     /// True when reputation is too hot — break off raiding and run for the
     /// hideout to lie low until it cools.
     pub lying_low: bool,
-    /// Hex of the world the cruise makes for to *finish* — the destination
-    /// when one is set, else the hideout.
-    pub terminal_hex: (i32, i32),
-    /// Hexes of the pirate's **havens** — safe ports (the home world and/or
-    /// destination, per their haven flags) where the pirate fences at law 0,
-    /// banks prizes, and lies low. The lying-low / prize drop-off diversions
-    /// make for the nearest of these. Empty when the pirate has no safe port,
-    /// in which case those diversions are simply skipped.
-    pub haven_hexes: Vec<(i32, i32)>,
+    /// **Absolute** hex of the world the cruise makes for to *finish* — the
+    /// destination when one is set, else the hideout. Absolute coords (see
+    /// [`Candidate::abs`]) so a finish line in another sector still works.
+    pub terminal_abs: (i32, i32),
+    /// Absolute hexes of the pirate's **havens** — safe ports (the home world
+    /// and/or destination, per their haven flags) where the pirate fences at
+    /// law 0, banks prizes, and lies low. The lying-low / prize drop-off
+    /// diversions make for the nearest of these. Empty when the pirate has no
+    /// safe port, in which case those diversions are simply skipped.
+    pub haven_abs: Vec<(i32, i32)>,
 }
 
 /// Hold-fullness fraction at/above which the pirate breaks to fence.
@@ -123,14 +124,14 @@ pub fn score_fence(c: &Candidate, ctx: &PirateRouteContext) -> f64 {
     fenceability - dist
 }
 
-/// Is this candidate at hex `target` (matched by coordinates)?
-fn is_at_hex(c: &Candidate, target: (i32, i32)) -> bool {
-    matches!(c.world.coordinates, Some((x, y)) if x == target.0 && y == target.1)
+/// Is this candidate at absolute hex `target`?
+fn is_at_abs(c: &Candidate, target: (i32, i32)) -> bool {
+    c.abs == target
 }
 
 /// From `pool`, the candidate that gets closest (in hexes) to *any* of
-/// `targets`, ties broken by hunt score. `None` only if `pool` has no
-/// candidate with coordinates (or `targets` is empty).
+/// `targets` (absolute coords), ties broken by hunt score. `None` only if
+/// `pool` or `targets` is empty.
 fn closest_to_any<'a>(
     pool: &[&'a Candidate],
     targets: &[(i32, i32)],
@@ -140,15 +141,13 @@ fn closest_to_any<'a>(
         return None;
     }
     pool.iter()
-        .filter_map(|c| {
-            c.world.coordinates.map(|(x, y)| {
-                let dist = targets
-                    .iter()
-                    .map(|t| calculate_hex_distance(x, y, t.0, t.1))
-                    .min()
-                    .unwrap_or(i32::MAX);
-                (*c, dist)
-            })
+        .map(|c| {
+            let dist = targets
+                .iter()
+                .map(|t| calculate_hex_distance(c.abs.0, c.abs.1, t.0, t.1))
+                .min()
+                .unwrap_or(i32::MAX);
+            (*c, dist)
         })
         .min_by(|a, b| {
             a.1.cmp(&b.1).then_with(|| {
@@ -184,7 +183,7 @@ pub fn pick_next_pirate<'a>(
     // finish world (destination, or hideout when none is set) is reachable,
     // take it regardless of score.
     if prog >= 1.0
-        && let Some(term) = candidates.iter().find(|c| is_at_hex(c, ctx.terminal_hex))
+        && let Some(term) = candidates.iter().find(|c| is_at_abs(c, ctx.terminal_abs))
     {
         return Some(term);
     }
@@ -202,14 +201,14 @@ pub fn pick_next_pirate<'a>(
     // lying low (reputation too hot), make for the nearest *haven* — a safe
     // port to bank prizes / let the heat cool — not the finish line. Skipped
     // when the pirate has no haven at all.
-    if (ctx.prize_run || ctx.lying_low) && !ctx.haven_hexes.is_empty() {
-        return closest_to_any(&pool, &ctx.haven_hexes, ctx);
+    if (ctx.prize_run || ctx.lying_low) && !ctx.haven_abs.is_empty() {
+        return closest_to_any(&pool, &ctx.haven_abs, ctx);
     }
 
     // Head for the finish: past the head-home threshold, spiral toward the
     // terminal (the destination when set, else the hideout).
     if prog >= HEAD_HOME_THRESHOLD {
-        return closest_to_any(&pool, &[ctx.terminal_hex], ctx);
+        return closest_to_any(&pool, &[ctx.terminal_abs], ctx);
     }
 
     // In the first half, exclude the terminal so the cruise doesn't end early
@@ -218,7 +217,7 @@ pub fn pick_next_pirate<'a>(
         let filtered: Vec<&Candidate> = pool
             .iter()
             .copied()
-            .filter(|c| !is_at_hex(c, ctx.terminal_hex))
+            .filter(|c| !is_at_abs(c, ctx.terminal_abs))
             .collect();
         if filtered.is_empty() { pool } else { filtered }
     } else {
@@ -254,6 +253,8 @@ mod tests {
     fn cand(uwp: &str, x: i32, y: i32, dist: i32, gas: u8) -> Candidate {
         Candidate {
             world: world(uwp, x, y),
+            sector: String::new(),
+            abs: (x, y),
             distance: dist,
             allegiance: None,
             gas_giants: gas,
@@ -273,12 +274,13 @@ mod tests {
 
     fn base<'a>(terminal: &'a WorldRef, history: &'a [WorldRef]) -> RouteContext<'a> {
         RouteContext {
-            terminal,
+            terminal_abs: (terminal.hex_x, terminal.hex_y),
             current_date: Date::new(10, 1105),
             start_date: Date::new(0, 1105),
             target_date: Date::new(100, 1105),
             jump: 2,
             fuel_cost_per_parsec: 10_000,
+            current_abs: (0, 0),
             history,
             direct_run: false,
         }
@@ -295,8 +297,8 @@ mod tests {
             ship_weapons: 6,
             prize_run: false,
             lying_low: false,
-            terminal_hex: (0, 0),      // == home hex by default (round-trip)
-            haven_hexes: vec![(0, 0)], // home is a haven by default
+            terminal_abs: (0, 0),     // == home hex by default (round-trip)
+            haven_abs: vec![(0, 0)],  // home is a haven by default
         }
     }
 
@@ -364,7 +366,7 @@ mod tests {
         let mut b = base(&h, &[]);
         b.current_date = Date::new(80, 1105); // prog 0.8, past HEAD_HOME_THRESHOLD
         let mut ctx = pctx(&b);
-        ctx.terminal_hex = (5, 0); // destination, distinct from home (0,0)
+        ctx.terminal_abs = (5, 0); // destination, distinct from home (0,0)
         // Hideout (0,0) and the destination (5,0), both refuelable.
         let hideout = cand("A788899-A", 0, 0, 1, 0);
         let dest = cand("A788899-A", 5, 0, 1, 0);
@@ -381,7 +383,7 @@ mod tests {
         let b = base(&h, &[]); // prog 0.1
         let mut ctx = pctx(&b);
         ctx.lying_low = true;
-        ctx.terminal_hex = (5, 0); // destination elsewhere
+        ctx.terminal_abs = (5, 0); // destination elsewhere
         let hideout = cand("A788899-A", 0, 0, 1, 0);
         let dest = cand("A788899-A", 5, 0, 1, 0);
         let cands = [dest, hideout];
@@ -398,7 +400,7 @@ mod tests {
         let b = base(&h, &[]); // prog 0.1
         let mut ctx = pctx(&b);
         ctx.prize_run = true;
-        ctx.haven_hexes = vec![(0, 0), (20, 0)];
+        ctx.haven_abs = vec![(0, 0), (20, 0)];
         let near_far_haven = cand("A788899-A", 18, 0, 1, 0); // 2 from (20,0)
         let midway = cand("A788899-A", 10, 0, 1, 0); // 10 from either haven
         let cands = [midway, near_far_haven];
@@ -415,7 +417,7 @@ mod tests {
         let b = base(&h, &[]); // prog 0.1
         let mut ctx = pctx(&b);
         ctx.lying_low = true;
-        ctx.haven_hexes = vec![];
+        ctx.haven_abs = vec![];
         let a = cand("A788899-A", 1, 0, 1, 0);
         let bb = cand("C788510-7", 2, 0, 1, 0);
         let cands = [a, bb];

--- a/src/simulator/piracy/route.rs
+++ b/src/simulator/piracy/route.rs
@@ -280,6 +280,7 @@ mod tests {
             jump: 2,
             fuel_cost_per_parsec: 10_000,
             history,
+            direct_run: false,
         }
     }
 

--- a/src/simulator/piracy/route.rs
+++ b/src/simulator/piracy/route.rs
@@ -271,9 +271,9 @@ mod tests {
         }
     }
 
-    fn base<'a>(home: &'a WorldRef, history: &'a [WorldRef]) -> RouteContext<'a> {
+    fn base<'a>(terminal: &'a WorldRef, history: &'a [WorldRef]) -> RouteContext<'a> {
         RouteContext {
-            home,
+            terminal,
             current_date: Date::new(10, 1105),
             start_date: Date::new(0, 1105),
             target_date: Date::new(100, 1105),

--- a/src/simulator/route.rs
+++ b/src/simulator/route.rs
@@ -18,9 +18,21 @@ use crate::trade::table::TradeTable;
 use crate::util::calculate_hex_distance;
 
 /// One destination world the planner is considering.
+#[derive(Clone)]
 pub struct Candidate {
-    /// The candidate world (already populated, with trade classes).
+    /// The candidate world (already populated, with trade classes). Its
+    /// `coordinates` are the **sector-local** hex, matching the wire-format
+    /// `WorldRef` the frontend renders.
     pub world: World,
+    /// Canonical TravellerMap sector name this world belongs to — its *own*
+    /// sector, which may differ from the current location's when the jump
+    /// neighbourhood spills across a sector boundary.
+    pub sector: String,
+    /// Absolute hex coordinates: `(sx*32 + hex_x, sy*40 + hex_y)` where
+    /// `(sx, sy)` are the sector's TravellerMap offsets. Globally unique and
+    /// parity-preserving, so `calculate_hex_distance` works across sector
+    /// boundaries. All planner distance math uses these.
+    pub abs: (i32, i32),
     /// Distance in parsecs from the current location to this candidate.
     pub distance: i32,
     /// TravellerMap allegiance code (e.g. `"Im"`, `"ImAp"`, `"AsT4"`,
@@ -39,13 +51,15 @@ pub struct Candidate {
 /// `history` is interpreted as **most-recent first** — index `0` is the
 /// last world we visited, index `1` is the one before that, etc.
 pub struct RouteContext<'a> {
-    /// The world the trip makes for to *finish*: the destination when one is
-    /// set, else the home world (a round trip). Drives the terminal bias, the
-    /// forced-terminal override, the head-for-finish spiral, and the
-    /// first-half exclusion (so the trip doesn't end early by arriving at the
-    /// finish world). Once the ship has left, routing only ever cares about
-    /// where it's headed — this world — not where it started.
-    pub terminal: &'a WorldRef,
+    /// Absolute hex of the world the trip makes for to *finish*: the
+    /// destination when one is set, else the home world (a round trip).
+    /// Drives the terminal bias, the forced-terminal override, the
+    /// head-for-finish spiral, and the first-half exclusion (so the trip
+    /// doesn't end early by arriving at the finish world). Once the ship has
+    /// left, routing only ever cares about where it's headed — this hex —
+    /// not where it started. Absolute (see [`Candidate::abs`]) so a terminal
+    /// in another sector still exerts a correct pull.
+    pub terminal_abs: (i32, i32),
     /// Current in-game date.
     pub current_date: Date,
     /// Date the run started — used to compute trip progress.
@@ -59,15 +73,23 @@ pub struct RouteContext<'a> {
     pub jump: i32,
     /// Fuel cost per parsec, used by the distance penalty.
     pub fuel_cost_per_parsec: i64,
+    /// Absolute hex of the ship's current position. On a direct run this
+    /// anchors the strict-progress filter: only candidates strictly closer
+    /// to the terminal than we are now stay in the pool.
+    pub current_abs: (i32, i32),
     /// Recently visited worlds, **most recent first**.
     pub history: &'a [WorldRef],
-    /// When `true`, the `terminal` is a distinct destination (a one-way run),
+    /// When `true`, the terminal is a distinct destination (a one-way run),
     /// not the home world of a round trip. The planner then steers toward the
     /// terminal from the very first hop: no first-half exclusion (arriving
-    /// early is fine) and a steady directional pull (`ROUTE_W_TERMINAL_DIRECT`)
-    /// so every stop makes net progress toward the destination. `false` → the
-    /// classic round trip: explore first, then lean home after the halfway
-    /// point via `ROUTE_W_HOME_BIAS`.
+    /// early is fine), a **strict-progress filter** (only candidates strictly
+    /// closer to the terminal than the current position stay in the pool, so
+    /// the ship can never move backward — distance monotonically decreases
+    /// and arrival is guaranteed; falls back to the full pool only when boxed
+    /// in), and a directional pull (`ROUTE_W_TERMINAL_DIRECT`) that favours
+    /// faster progress among the forward options. `false` → the classic
+    /// round trip: explore first, then lean home after the halfway point via
+    /// `ROUTE_W_HOME_BIAS`.
     pub direct_run: bool,
 }
 
@@ -108,12 +130,12 @@ pub const ROUTE_W_HOME_BIAS: f64 = 50_000.0;
 
 /// Directional pull toward the terminal on a **direct run** (a one-way trip
 /// to a distinct destination — see `RouteContext::direct_run`). Applied per
-/// hex of remaining distance to the terminal, from the very first hop, so
-/// every stop makes net progress toward the destination. Sized to reliably
-/// out-steer port/population bonuses (a few hexes of progress ≈ a port-A
-/// bonus) while still yielding to a genuinely outsized on-the-way trade — the
-/// ship trades opportunistically but always advances, arriving early rather
-/// than backtracking. Round trips use `ROUTE_W_HOME_BIAS` instead.
+/// hex of remaining distance to the terminal, from the very first hop.
+/// "Never move backward" is enforced structurally by the strict-progress
+/// filter in `pick_next`, not by this weight — the pull's job is only to
+/// favour *faster* progress among the forward options (a few hexes ≈ a
+/// port-A bonus), while a genuinely outsized on-the-way trade can still
+/// justify the slower forward stop. Round trips use `ROUTE_W_HOME_BIAS`.
 pub const ROUTE_W_TERMINAL_DIRECT: f64 = 200_000.0;
 
 /// Trip-progress fraction at which the planner abandons trade-value
@@ -156,15 +178,16 @@ pub fn score_candidate(
     // 4) Distance penalty.
     score -= candidate.distance as f64 * ctx.fuel_cost_per_parsec as f64 * ROUTE_W_DIST;
 
-    // 5) History penalty. Match by (sector, hex_x, hex_y), not name.
+    // 5) History penalty. Match by (sector, hex_x, hex_y), not name — the
+    //    candidate's own sector against the history entry's, so the same
+    //    local hex in a *different* sector doesn't false-match.
     //    Decays linearly with recency: most recent → full penalty,
     //    second most recent → half, third → third, etc.
-    let cand_sector = home_sector_of(candidate);
-    if let Some((sector, hx, hy)) = cand_sector
+    if let Some((hx, hy)) = candidate.world.coordinates
         && let Some(idx) = ctx
             .history
             .iter()
-            .position(|w| w.sector == sector && w.hex_x == hx && w.hex_y == hy)
+            .position(|w| w.sector == candidate.sector && w.hex_x == hx && w.hex_y == hy)
     {
         let recency = (idx as f64) + 1.0;
         score -= ROUTE_W_HISTORY / recency;
@@ -174,13 +197,15 @@ pub fn score_candidate(
     //    set, else home). On a direct run to a distinct destination we steer
     //    from the very first hop with a steady, stronger pull so every stop
     //    makes net progress; on a round trip we explore first and lean home
-    //    only after the halfway point.
-    if let (Some(cand_coords), Some(term_coords)) =
-        (candidate.world.coordinates, sector_hex_of(ctx.terminal))
+    //    only after the halfway point. Absolute coords, so the pull is
+    //    correct even when the terminal lies in another sector.
     {
-        let dist_term =
-            calculate_hex_distance(cand_coords.0, cand_coords.1, term_coords.0, term_coords.1)
-                as f64;
+        let dist_term = calculate_hex_distance(
+            candidate.abs.0,
+            candidate.abs.1,
+            ctx.terminal_abs.0,
+            ctx.terminal_abs.1,
+        ) as f64;
         if ctx.direct_run {
             score -= dist_term * ROUTE_W_TERMINAL_DIRECT;
         } else {
@@ -235,9 +260,8 @@ pub fn is_allegiance_friendly(allegiance: Option<&str>) -> bool {
 /// the list is empty.
 ///
 /// Forced-terminal override: if we're at or past the target date and any
-/// candidate is the terminal world — the destination when set, else home
-/// (matched by `sector + hex_x + hex_y`) — that candidate wins immediately
-/// regardless of score.
+/// candidate is the terminal world (matched by absolute hex), that
+/// candidate wins immediately regardless of score.
 pub fn pick_next<'a>(
     candidates: &'a [Candidate],
     market: &AvailableGoodsTable,
@@ -258,13 +282,29 @@ pub fn pick_next<'a>(
     // a distinct destination we skip this: arriving early is fine, and the
     // directional pull in `score_candidate` steers us there steadily.
     // Falls back to all candidates if the terminal is somehow the only option.
-    let is_terminal = |c: &&Candidate| -> bool {
-        matches!(
-            home_sector_of(c),
-            Some((_, hx, hy)) if hx == ctx.terminal.hex_x && hy == ctx.terminal.hex_y
-        )
+    let is_terminal = |c: &&Candidate| -> bool { c.abs == ctx.terminal_abs };
+    let dist_to_terminal = |p: (i32, i32)| -> i32 {
+        calculate_hex_distance(p.0, p.1, ctx.terminal_abs.0, ctx.terminal_abs.1)
     };
-    let candidates_for_search: Vec<&Candidate> = if progress < 0.5 && !ctx.direct_run {
+    let candidates_for_search: Vec<&Candidate> = if ctx.direct_run {
+        // Strict-progress filter: on a direct run, only candidates strictly
+        // closer to the terminal than the current position are eligible —
+        // the ship never moves backward, no matter how rich a market behind
+        // it looks, so remaining distance decreases every hop and arrival is
+        // guaranteed. Falls back to the full pool only when boxed in (no
+        // forward world within jump range), where a sidestep is the only way
+        // out.
+        let cur_d = dist_to_terminal(ctx.current_abs);
+        let forward: Vec<&Candidate> = candidates
+            .iter()
+            .filter(|c| dist_to_terminal(c.abs) < cur_d)
+            .collect();
+        if forward.is_empty() {
+            candidates.iter().collect()
+        } else {
+            forward
+        }
+    } else if progress < 0.5 {
         let filtered: Vec<&Candidate> = candidates.iter().filter(|c| !is_terminal(c)).collect();
         if filtered.is_empty() {
             candidates.iter().collect()
@@ -277,17 +317,12 @@ pub fn pick_next<'a>(
 
     // Forced-terminal override. At or past target, if the finish world
     // (destination, or home when none is set) is reachable, take it
-    // regardless of score. v1 is in-sector, so we match purely on hex
-    // coordinates.
-    if progress >= 1.0 {
-        for c in candidates {
-            if let Some((_, hx, hy)) = home_sector_of(c)
-                && hx == ctx.terminal.hex_x
-                && hy == ctx.terminal.hex_y
-            {
-                return Some(c);
-            }
-        }
+    // regardless of score. Matched on absolute hex, so it works across
+    // sector boundaries.
+    if progress >= 1.0
+        && let Some(term) = candidates.iter().find(|c| c.abs == ctx.terminal_abs)
+    {
+        return Some(term);
     }
 
     // Head-for-finish mode. Past `HEAD_HOME_THRESHOLD` of trip progress, the
@@ -295,16 +330,17 @@ pub fn pick_next<'a>(
     // the terminal-bias penalty, so we override it entirely: pick the
     // candidate with the smallest hex distance to the terminal, breaking ties
     // by score.
-    if progress >= HEAD_HOME_THRESHOLD
-        && let Some(term_coords) = sector_hex_of(ctx.terminal)
-    {
+    if progress >= HEAD_HOME_THRESHOLD {
         return candidates
             .iter()
-            .filter_map(|c| {
-                c.world.coordinates.map(|(x, y)| {
-                    let dh = calculate_hex_distance(x, y, term_coords.0, term_coords.1);
-                    (c, dh)
-                })
+            .map(|c| {
+                let dh = calculate_hex_distance(
+                    c.abs.0,
+                    c.abs.1,
+                    ctx.terminal_abs.0,
+                    ctx.terminal_abs.1,
+                );
+                (c, dh)
             })
             .min_by(|a, b| {
                 a.1.cmp(&b.1).then_with(|| {
@@ -326,27 +362,6 @@ pub fn pick_next<'a>(
 }
 
 // ---- helpers --------------------------------------------------------------
-
-/// Return `(sector, hex_x, hex_y)` for a candidate world, if its
-/// coordinates are populated. We don't have a sector on the `World`
-/// itself, so it comes back empty — the caller compares against the
-/// home `WorldRef.sector` separately.
-///
-/// In v1 the simulator is in-sector, so all worlds share one sector;
-/// equality on sector is implicitly satisfied. We surface only the
-/// hex pair here and let the history-match code combine sectors at the
-/// `WorldRef` level.
-fn home_sector_of(candidate: &Candidate) -> Option<(String, i32, i32)> {
-    candidate
-        .world
-        .coordinates
-        .map(|(x, y)| (String::new(), x, y))
-}
-
-/// Convenience — extract `(hex_x, hex_y)` from a `WorldRef`.
-fn sector_hex_of(w: &WorldRef) -> Option<(i32, i32)> {
-    Some((w.hex_x, w.hex_y))
-}
 
 /// Local copy of the `find_max_dm` helper used in `available_goods.rs`.
 /// Returns the max DM across the candidate world's trade classes, or 0
@@ -397,6 +412,18 @@ mod tests {
         w
     }
 
+    /// Test candidate: single unnamed sector, so `abs` == the local hex.
+    fn cand(name: &str, uwp: &str, x: i32, y: i32, distance: i32) -> Candidate {
+        Candidate {
+            world: mk_world(name, uwp, x, y),
+            sector: String::new(),
+            abs: (x, y),
+            distance,
+            allegiance: None,
+            gas_giants: 0,
+        }
+    }
+
     fn mk_world_ref(name: &str, uwp: &str, x: i32, y: i32) -> WorldRef {
         WorldRef {
             name: name.to_string(),
@@ -408,14 +435,18 @@ mod tests {
         }
     }
 
-    fn ctx<'a>(terminal: &'a WorldRef, history: &'a [WorldRef]) -> RouteContext<'a> {
+    fn ctx(terminal_abs: (i32, i32), history: &[WorldRef]) -> RouteContext<'_> {
         RouteContext {
-            terminal,
+            terminal_abs,
             current_date: Date::new(0, 1105),
             start_date: Date::new(0, 1105),
             target_date: Date::new(100, 1105),
             jump: 2,
             fuel_cost_per_parsec: 10_000,
+            // Far from every test terminal by default, so the direct-run
+            // strict-progress filter keeps all candidates unless a test
+            // positions the ship deliberately.
+            current_abs: (100, 100),
             history,
             direct_run: false,
         }
@@ -423,9 +454,8 @@ mod tests {
 
     #[test]
     fn empty_candidates_returns_none() {
-        let home = mk_world_ref("Home", "A788899-A", 0, 0);
         let market = AvailableGoodsTable::default();
-        let c = ctx(&home, &[]);
+        let c = ctx((0, 0), &[]);
         assert!(pick_next(&[], &market, &c).is_none());
     }
 
@@ -433,26 +463,13 @@ mod tests {
     fn forced_home_when_past_target() {
         // Two candidates: a wonderful non-home world and home itself.
         // Past target date, home should win regardless of score.
-        let home_ref = mk_world_ref("Home", "A788899-A", 5, 5);
-
-        let great = Candidate {
-            world: mk_world("Great", "A999999-F", 1, 1),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let home = Candidate {
-            world: mk_world("Home", "A788899-A", 5, 5),
-            distance: 4,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let great = cand("Great", "A999999-F", 1, 1, 1);
+        let home = cand("Home", "A788899-A", 5, 5, 4);
 
         let market = AvailableGoodsTable::default();
-        let mut c = ctx(&home_ref, &[]);
+        let mut c = ctx((5, 5), &[]);
         c.current_date = Date::new(150, 1105); // past target (100)
 
-        // Order matters? Try both orders.
         let cands = [great, home];
         let chosen = pick_next(&cands, &market, &c).unwrap();
         assert_eq!(chosen.world.name, "Home");
@@ -461,21 +478,10 @@ mod tests {
     #[test]
     fn closer_preferred_all_else_equal() {
         // Two identical worlds at different distances → closer wins.
-        let home_ref = mk_world_ref("Home", "A788899-A", 0, 0);
-        let near = Candidate {
-            world: mk_world("Near", "C555555-7", 1, 0),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let far = Candidate {
-            world: mk_world("Far", "C555555-7", 3, 0),
-            distance: 3,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let near = cand("Near", "C555555-7", 1, 0, 1);
+        let far = cand("Far", "C555555-7", 3, 0, 3);
         let market = AvailableGoodsTable::default();
-        let c = ctx(&home_ref, &[]);
+        let c = ctx((0, 0), &[]);
 
         let cands = [near, far];
         let chosen = pick_next(&cands, &market, &c).unwrap();
@@ -485,21 +491,10 @@ mod tests {
     #[test]
     fn higher_port_wins_all_else_equal() {
         // Same UWP-body except port: A vs E, identical distance.
-        let home_ref = mk_world_ref("Home", "A788899-A", 0, 0);
-        let porta = Candidate {
-            world: mk_world("PortA", "A555555-7", 1, 0),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let porte = Candidate {
-            world: mk_world("PortE", "E555555-7", 0, 1),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let porta = cand("PortA", "A555555-7", 1, 0, 1);
+        let porte = cand("PortE", "E555555-7", 0, 1, 1);
         let market = AvailableGoodsTable::default();
-        let c = ctx(&home_ref, &[]);
+        let c = ctx((0, 0), &[]);
 
         let cands = [porta, porte];
         let chosen = pick_next(&cands, &market, &c).unwrap();
@@ -508,26 +503,15 @@ mod tests {
 
     #[test]
     fn history_penalty_applies() {
-        let home_ref = mk_world_ref("Home", "A788899-A", 0, 0);
         let visited_ref = mk_world_ref("Visited", "C555555-7", 1, 0);
 
         // Same shape candidates; only difference is whether history has it.
-        let visited_cand = Candidate {
-            world: mk_world("Visited", "C555555-7", 1, 0),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let fresh_cand = Candidate {
-            world: mk_world("Fresh", "C555555-7", 0, 1),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let visited_cand = cand("Visited", "C555555-7", 1, 0, 1);
+        let fresh_cand = cand("Fresh", "C555555-7", 0, 1, 1);
 
         let market = AvailableGoodsTable::default();
         let history = vec![visited_ref];
-        let c = ctx(&home_ref, &history);
+        let c = ctx((0, 0), &history);
 
         let visited_score = score_candidate(&visited_cand, &market, &c);
         let fresh_score = score_candidate(&fresh_cand, &market, &c);
@@ -542,43 +526,45 @@ mod tests {
     }
 
     #[test]
+    fn history_requires_matching_sector() {
+        // Same local hex, DIFFERENT sector → not a revisit. Cross-sector
+        // routes must not false-match history entries by hex alone.
+        let mut visited_ref = mk_world_ref("Visited", "C555555-7", 1, 0);
+        visited_ref.sector = "Spinward Marches".to_string();
+
+        // The candidate is at local hex (1,0) too, but in another sector.
+        let mut lookalike = cand("Lookalike", "C555555-7", 1, 0, 1);
+        lookalike.sector = "Trojan Reach".to_string();
+
+        let market = AvailableGoodsTable::default();
+        let history = vec![visited_ref];
+        let c = ctx((0, 0), &history);
+
+        // A genuinely fresh world in a third position for comparison.
+        let fresh = cand("Fresh", "C555555-7", 0, 1, 1);
+        let lookalike_score = score_candidate(&lookalike, &market, &c);
+        let fresh_score = score_candidate(&fresh, &market, &c);
+        // Neither carries a history penalty; the tiny difference left is
+        // the terminal-distance bias, which is zero this early in the trip.
+        assert!(
+            (lookalike_score - fresh_score).abs() < 1.0,
+            "sector-mismatched candidate must not be history-penalized; got {lookalike_score} vs {fresh_score}"
+        );
+    }
+
+    #[test]
     fn home_bias_kicks_in_after_halfway() {
         // Home at (0,0). One candidate near home, one far. Far has a
         // small port advantage that's enough to win when the bias is
         // off, but should lose once we're past 50% of the trip.
-        let home_ref = mk_world_ref("Home", "A788899-A", 0, 0);
-
-        let near_home = Candidate {
-            world: mk_world("Near", "C555555-7", 1, 0),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let far_with_a = Candidate {
-            world: mk_world("FarA", "A555555-7", 8, 0),
-            distance: 1, // distance from current location, not from home
-            allegiance: None,
-            gas_giants: 0,
-        };
-
         let market = AvailableGoodsTable::default();
 
         // Early in trip: FarA's port-A bonus should beat Near.
-        let mut c_early = ctx(&home_ref, &[]);
+        let mut c_early = ctx((0, 0), &[]);
         c_early.current_date = Date::new(0, 1105); // progress = 0
         let cands_early = [
-            Candidate {
-                world: near_home.world.clone(),
-                distance: 1,
-                allegiance: None,
-                gas_giants: 0,
-            },
-            Candidate {
-                world: far_with_a.world.clone(),
-                distance: 1,
-                allegiance: None,
-                gas_giants: 0,
-            },
+            cand("Near", "C555555-7", 1, 0, 1),
+            cand("FarA", "A555555-7", 8, 0, 1),
         ];
         let early = pick_next(&cands_early, &market, &c_early).unwrap();
         assert_eq!(
@@ -586,23 +572,13 @@ mod tests {
             "Early in trip, port-A world should win"
         );
 
-        // Late in trip: home bias on far_with_a (far from home) should
+        // Late in trip: home bias on FarA (far from home) should
         // outweigh its port-A bonus.
-        let mut c_late = ctx(&home_ref, &[]);
+        let mut c_late = ctx((0, 0), &[]);
         c_late.current_date = Date::new(95, 1105); // progress ~ 0.95
         let cands_late = [
-            Candidate {
-                world: near_home.world.clone(),
-                distance: 1,
-                allegiance: None,
-                gas_giants: 0,
-            },
-            Candidate {
-                world: far_with_a.world.clone(),
-                distance: 1,
-                allegiance: None,
-                gas_giants: 0,
-            },
+            cand("Near", "C555555-7", 1, 0, 1),
+            cand("FarA", "A555555-7", 8, 0, 1),
         ];
         let late = pick_next(&cands_late, &market, &c_late).unwrap();
         assert_eq!(
@@ -620,8 +596,6 @@ mod tests {
         // should win because the sale_dm is favourable there. We pick
         // worlds whose other features (population, port) are roughly
         // balanced so the trade-value signal dominates.
-        let home_ref = mk_world_ref("Home", "A788899-A", 0, 0);
-
         let entry_52 = TradeTable::global()
             .get(52)
             .expect("trade table entry 52 should exist");
@@ -649,40 +623,29 @@ mod tests {
         // World::gen_trade_classes). UWP "A302666-7": port A, size 3,
         // atm 0, hydro 2, pop 6 → Non-Ag (also Vacuum and
         // NonIndustrial; that's fine).
-        let non_ag_world = mk_world("NonAg", "A302666-7", 1, 0);
+        let non_ag = cand("NonAg", "A302666-7", 1, 0, 1);
         assert!(
-            non_ag_world
+            non_ag
+                .world
                 .get_trade_classes()
                 .contains(&TradeClass::NonAgricultural),
             "fixture should be Non-Agricultural; got {:?}",
-            non_ag_world.get_trade_classes()
+            non_ag.world.get_trade_classes()
         );
 
         // Neutral counterpart: same population, same port, but not Non-Ag.
         // A666666-7 has atm 6, hydro 6, pop 6 → Agricultural+Rich, not Non-Ag.
-        let neutral_world = mk_world("Neutral", "A666666-7", 0, 1);
+        let neutral = cand("Neutral", "A666666-7", 0, 1, 1);
         assert!(
-            !neutral_world
+            !neutral
+                .world
                 .get_trade_classes()
                 .contains(&TradeClass::NonAgricultural),
             "neutral fixture shouldn't be Non-Agricultural; got {:?}",
-            neutral_world.get_trade_classes()
+            neutral.world.get_trade_classes()
         );
 
-        let non_ag = Candidate {
-            world: non_ag_world,
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let neutral = Candidate {
-            world: neutral_world,
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-
-        let c = ctx(&home_ref, &[]);
+        let c = ctx((0, 0), &[]);
 
         // Score directly first to compare the two.
         let s_non_ag = score_candidate(&non_ag, &market, &c);
@@ -705,21 +668,10 @@ mod tests {
         // Home is a great trade target (high pop, A port), but in the first
         // half of the trip we should NOT pick it — otherwise the trip ends
         // immediately. Should pick the non-home option.
-        let home_ref = mk_world_ref("Home", "A999999-F", 5, 5);
-        let home = Candidate {
-            world: mk_world("Home", "A999999-F", 5, 5),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let other = Candidate {
-            world: mk_world("Other", "C555555-7", 6, 5),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let home = cand("Home", "A999999-F", 5, 5, 1);
+        let other = cand("Other", "C555555-7", 6, 5, 1);
         let market = AvailableGoodsTable::default();
-        let mut c = ctx(&home_ref, &[]);
+        let mut c = ctx((5, 5), &[]);
         c.current_date = Date::new(10, 1105); // ~10% progress
 
         let cands = [home, other];
@@ -731,21 +683,10 @@ mod tests {
     fn home_allowed_after_halfway() {
         // Same setup as above but past 50% progress — home becomes eligible
         // and (because A-port pop 9) should win on score.
-        let home_ref = mk_world_ref("Home", "A999999-F", 5, 5);
-        let home = Candidate {
-            world: mk_world("Home", "A999999-F", 5, 5),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let other = Candidate {
-            world: mk_world("Other", "C555555-7", 6, 5),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let home = cand("Home", "A999999-F", 5, 5, 1);
+        let other = cand("Other", "C555555-7", 6, 5, 1);
         let market = AvailableGoodsTable::default();
-        let mut c = ctx(&home_ref, &[]);
+        let mut c = ctx((5, 5), &[]);
         c.current_date = Date::new(60, 1105); // 60% progress
 
         let cands = [home, other];
@@ -759,21 +700,10 @@ mod tests {
         // closest to home (not the one with the best trade score). Set up:
         // home at (0, 0). A great trade world far from home (5 hexes) vs a
         // mediocre one near home (1 hex). The mediocre one must win.
-        let home_ref = mk_world_ref("Home", "A788899-A", 0, 0);
-        let great_far = Candidate {
-            world: mk_world("Great", "A999999-F", 5, 0),
-            distance: 2,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let mediocre_near = Candidate {
-            world: mk_world("Near", "E555555-5", 1, 0),
-            distance: 2,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let great_far = cand("Great", "A999999-F", 5, 0, 2);
+        let mediocre_near = cand("Near", "E555555-5", 1, 0, 2);
         let market = AvailableGoodsTable::default();
-        let mut c = ctx(&home_ref, &[]);
+        let mut c = ctx((0, 0), &[]);
         c.current_date = Date::new(80, 1105); // 80% progress, past 0.75
 
         let cands = [great_far, mediocre_near];
@@ -787,21 +717,10 @@ mod tests {
         // start), past the head-home threshold the planner must spiral toward
         // the *destination*, not back toward the origin. A great trade world
         // sitting at the origin must lose to a mediocre one at the destination.
-        let dest_ref = mk_world_ref("Dest", "A788899-A", 5, 0);
-        let great_at_origin = Candidate {
-            world: mk_world("Great", "A999999-F", 0, 0),
-            distance: 2,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let mediocre_at_dest = Candidate {
-            world: mk_world("AtDest", "E555555-5", 5, 0),
-            distance: 2,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let great_at_origin = cand("Great", "A999999-F", 0, 0, 2);
+        let mediocre_at_dest = cand("AtDest", "E555555-5", 5, 0, 2);
         let market = AvailableGoodsTable::default();
-        let mut c = ctx(&dest_ref, &[]); // terminal = destination (5,0)
+        let mut c = ctx((5, 0), &[]); // terminal = destination (5,0)
         c.current_date = Date::new(80, 1105); // 80% progress, past 0.75
 
         let cands = [great_at_origin, mediocre_at_dest];
@@ -810,25 +729,45 @@ mod tests {
     }
 
     #[test]
+    fn cross_sector_terminal_pull_uses_absolute_coords() {
+        // The terminal lies in the next sector coreward: local hexes would
+        // put it "far away" (or at a phantom in-sector position), but the
+        // absolute coords place it just past the boundary. Of two forward
+        // options, the one closer in ABSOLUTE terms must win the
+        // head-for-finish spiral, even though its *local* hex is not closer
+        // to the terminal's local hex.
+        //
+        // Layout (absolute columns 10, rows around the sector seam at 0):
+        //   terminal   abs (10, -2)  — two rows into the coreward sector
+        //   nearer     abs (10,  1)  — local hex (10, 1), 3 rows from terminal
+        //   farther    abs (10,  6)  — local hex (10, 6), 8 rows from terminal
+        //
+        // In *local-hex* space the terminal would sit at (10, 38) of its own
+        // sector — nearer to local (10,6) than to (10,1) — so a local-hex
+        // planner picks the wrong world. Absolute coords pick correctly.
+        let mut nearer = cand("Nearer", "E555555-5", 10, 1, 2);
+        nearer.abs = (10, 1);
+        let mut farther = cand("Farther", "A999999-F", 10, 6, 2);
+        farther.abs = (10, 6);
+
+        let market = AvailableGoodsTable::default();
+        let mut c = ctx((10, -2), &[]); // terminal beyond the sector seam
+        c.current_date = Date::new(80, 1105); // head-for-finish mode
+
+        let cands = [farther, nearer];
+        let chosen = pick_next(&cands, &market, &c).unwrap();
+        assert_eq!(chosen.world.name, "Nearer");
+    }
+
+    #[test]
     fn terminal_excluded_in_first_half_on_round_trip() {
         // On a round trip (no destination), the planner must not end early by
         // arriving home in the first half — even if home scores best. Home is
         // excluded from the first-half candidate pool.
-        let home_ref = mk_world_ref("Home", "A999999-F", 5, 5);
-        let home = Candidate {
-            world: mk_world("Home", "A999999-F", 5, 5),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let other = Candidate {
-            world: mk_world("Other", "C555555-7", 6, 5),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let home = cand("Home", "A999999-F", 5, 5, 1);
+        let other = cand("Other", "C555555-7", 6, 5, 1);
         let market = AvailableGoodsTable::default();
-        let mut c = ctx(&home_ref, &[]); // direct_run = false (round trip)
+        let mut c = ctx((5, 5), &[]); // direct_run = false (round trip)
         c.current_date = Date::new(10, 1105); // ~10% progress
 
         let cands = [home, other];
@@ -841,21 +780,10 @@ mod tests {
         // On a direct run to a distinct destination, arriving early is fine:
         // the destination is NOT excluded in the first half, and when it's the
         // best-scoring option it wins (contrast the round-trip test above).
-        let dest_ref = mk_world_ref("Dest", "A999999-F", 5, 5);
-        let dest = Candidate {
-            world: mk_world("Dest", "A999999-F", 5, 5),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
-        let other = Candidate {
-            world: mk_world("Other", "C555555-7", 6, 5),
-            distance: 1,
-            allegiance: None,
-            gas_giants: 0,
-        };
+        let dest = cand("Dest", "A999999-F", 5, 5, 1);
+        let other = cand("Other", "C555555-7", 6, 5, 1);
         let market = AvailableGoodsTable::default();
-        let mut c = ctx(&dest_ref, &[]);
+        let mut c = ctx((5, 5), &[]);
         c.current_date = Date::new(10, 1105); // ~10% progress
         c.direct_run = true;
 
@@ -871,29 +799,18 @@ mod tests {
         // closer to the destination wins on the directional pull — even against
         // a port-A advantage on the farther one. A round trip at the same early
         // point has no such pull, so the port-A world wins there instead.
-        let dest_ref = mk_world_ref("Dest", "A788899-A", 6, 0);
         let mk_cands = || {
             [
                 // Farther from the destination (4 hexes) but a nicer port.
-                Candidate {
-                    world: mk_world("Away", "A555555-5", 2, 0),
-                    distance: 1,
-                    allegiance: None,
-                    gas_giants: 0,
-                },
+                cand("Away", "A555555-5", 2, 0, 1),
                 // Closer to the destination (1 hex), plainer port.
-                Candidate {
-                    world: mk_world("Toward", "E555555-5", 5, 0),
-                    distance: 1,
-                    allegiance: None,
-                    gas_giants: 0,
-                },
+                cand("Toward", "E555555-5", 5, 0, 1),
             ]
         };
         let market = AvailableGoodsTable::default();
 
         // Direct run, 10% in: the directional pull picks the closer world.
-        let mut c_direct = ctx(&dest_ref, &[]);
+        let mut c_direct = ctx((6, 0), &[]);
         c_direct.current_date = Date::new(10, 1105);
         c_direct.direct_run = true;
         let direct_cands = mk_cands();
@@ -901,11 +818,44 @@ mod tests {
         assert_eq!(direct.world.name, "Toward");
 
         // Round trip, same early point: no directional pull yet → port-A wins.
-        let mut c_round = ctx(&dest_ref, &[]);
+        let mut c_round = ctx((6, 0), &[]);
         c_round.current_date = Date::new(10, 1105);
         let round_cands = mk_cands();
         let round = pick_next(&round_cands, &market, &c_round).unwrap();
         assert_eq!(round.world.name, "Away");
+    }
+
+    #[test]
+    fn direct_run_never_moves_backward() {
+        // The strict-progress filter: a fabulously rich market BEHIND the
+        // ship must lose to a modest world ahead — no trade score can buy a
+        // backward hop on a direct run.
+        let rich_behind = cand("RichBehind", "A999999-F", 3, 0, 2);
+        let modest_ahead = cand("ModestAhead", "E555555-5", 7, 0, 2);
+        let market = AvailableGoodsTable::default();
+        let mut c = ctx((10, 0), &[]); // terminal well ahead
+        c.current_abs = (5, 0); // ship between the two candidates
+        c.current_date = Date::new(10, 1105); // early in the trip
+        c.direct_run = true;
+
+        let cands = [rich_behind, modest_ahead];
+        let chosen = pick_next(&cands, &market, &c).unwrap();
+        assert_eq!(chosen.world.name, "ModestAhead");
+    }
+
+    #[test]
+    fn direct_run_boxed_in_falls_back_to_full_pool() {
+        // If nothing within jump range makes progress (a dead end), the
+        // planner must still return something — a sidestep beats a stall.
+        let backward = cand("OnlyOption", "C555555-7", 3, 0, 2);
+        let market = AvailableGoodsTable::default();
+        let mut c = ctx((10, 0), &[]);
+        c.current_abs = (5, 0); // the only candidate is behind us
+        c.direct_run = true;
+
+        let cands = [backward];
+        let chosen = pick_next(&cands, &market, &c).unwrap();
+        assert_eq!(chosen.world.name, "OnlyOption");
     }
 
     #[test]
@@ -940,21 +890,16 @@ mod tests {
     fn foreign_empire_loses_to_friendly() {
         // A great-on-paper foreign world (A-port, high pop) should still
         // lose to a mediocre Imperial world thanks to the heavy penalty.
-        let home_ref = mk_world_ref("Home", "A788899-A", 0, 0);
         let foreign_great = Candidate {
-            world: mk_world("AslanA", "A999999-F", 1, 0),
-            distance: 1,
             allegiance: Some("AsT4".to_string()),
-            gas_giants: 0,
+            ..cand("AslanA", "A999999-F", 1, 0, 1)
         };
         let imperial_meh = Candidate {
-            world: mk_world("ImpC", "C555555-7", 2, 0),
-            distance: 2,
             allegiance: Some("Im".to_string()),
-            gas_giants: 0,
+            ..cand("ImpC", "C555555-7", 2, 0, 2)
         };
         let market = AvailableGoodsTable::default();
-        let c = ctx(&home_ref, &[]);
+        let c = ctx((0, 0), &[]);
 
         let cands = [foreign_great, imperial_meh];
         let chosen = pick_next(&cands, &market, &c).unwrap();
@@ -969,15 +914,12 @@ mod tests {
         // If foreign space is the *only* option, the planner still
         // returns it rather than `None` — the penalty is heavy but not
         // a hard block.
-        let home_ref = mk_world_ref("Home", "A788899-A", 0, 0);
         let only_foreign = Candidate {
-            world: mk_world("Zhodane", "C555555-7", 1, 0),
-            distance: 1,
             allegiance: Some("Zh".to_string()),
-            gas_giants: 0,
+            ..cand("Zhodane", "C555555-7", 1, 0, 1)
         };
         let market = AvailableGoodsTable::default();
-        let c = ctx(&home_ref, &[]);
+        let c = ctx((0, 0), &[]);
 
         let cands = [only_foreign];
         let chosen = pick_next(&cands, &market, &c).unwrap();

--- a/src/simulator/route.rs
+++ b/src/simulator/route.rs
@@ -39,8 +39,13 @@ pub struct Candidate {
 /// `history` is interpreted as **most-recent first** — index `0` is the
 /// last world we visited, index `1` is the one before that, etc.
 pub struct RouteContext<'a> {
-    /// Home world (for the "head home" bias and forced-home override).
-    pub home: &'a WorldRef,
+    /// The world the trip makes for to *finish*: the destination when one is
+    /// set, else the home world (a round trip). Drives the terminal bias, the
+    /// forced-terminal override, the head-for-finish spiral, and the
+    /// first-half exclusion (so the trip doesn't end early by arriving at the
+    /// finish world). Once the ship has left, routing only ever cares about
+    /// where it's headed — this world — not where it started.
+    pub terminal: &'a WorldRef,
     /// Current in-game date.
     pub current_date: Date,
     /// Date the run started — used to compute trip progress.
@@ -147,21 +152,22 @@ pub fn score_candidate(
         score -= ROUTE_W_HISTORY / recency;
     }
 
-    // 6) Home bias. Past 50% of the trip, push toward home.
+    // 6) Terminal bias. Past 50% of the trip, push toward the finish world
+    //    (the destination when set, else home).
     let total = ctx.start_date.days_until(ctx.target_date) as f64;
     let elapsed = ctx.start_date.days_until(ctx.current_date) as f64;
     if total > 0.0 {
         let progress = elapsed / total;
         if progress > 0.5
-            && let (Some(cand_coords), Some(home_coords)) =
-                (candidate.world.coordinates, sector_hex_of(ctx.home))
+            && let (Some(cand_coords), Some(term_coords)) =
+                (candidate.world.coordinates, sector_hex_of(ctx.terminal))
         {
-            let dist_home =
-                calculate_hex_distance(cand_coords.0, cand_coords.1, home_coords.0, home_coords.1)
+            let dist_term =
+                calculate_hex_distance(cand_coords.0, cand_coords.1, term_coords.0, term_coords.1)
                     as f64;
             // Linear ramp: 0 at progress=0.5, full at progress>=1.0.
             let ramp = ((progress - 0.5) / 0.5).clamp(0.0, 1.0);
-            score -= dist_home * ROUTE_W_HOME_BIAS * ramp;
+            score -= dist_term * ROUTE_W_HOME_BIAS * ramp;
         }
     }
 
@@ -202,9 +208,10 @@ pub fn is_allegiance_friendly(allegiance: Option<&str>) -> bool {
 /// Pick the best destination from `candidates`. Returns `None` only if
 /// the list is empty.
 ///
-/// Forced-home override: if we're at or past the target date and any
-/// candidate is the home world (matched by `sector + hex_x + hex_y`),
-/// that candidate wins immediately regardless of score.
+/// Forced-terminal override: if we're at or past the target date and any
+/// candidate is the terminal world — the destination when set, else home
+/// (matched by `sector + hex_x + hex_y`) — that candidate wins immediately
+/// regardless of score.
 pub fn pick_next<'a>(
     candidates: &'a [Candidate],
     market: &AvailableGoodsTable,
@@ -218,19 +225,19 @@ pub fn pick_next<'a>(
     let elapsed = ctx.start_date.days_until(ctx.current_date) as f64;
     let progress = if total > 0.0 { elapsed / total } else { 0.0 };
 
-    // Exclude home from the candidate pool while we're still in the first
-    // half of the trip — otherwise the planner returns home immediately on
-    // the first or second hop because home worlds are typically high-pop
-    // A-port and score very well. Falls back to all candidates if home is
-    // somehow the only option.
-    let is_home = |c: &&Candidate| -> bool {
+    // Exclude the terminal from the candidate pool while we're still in the
+    // first half of the trip — otherwise the planner heads for the finish
+    // immediately on the first or second hop (home/destination worlds are
+    // typically high-pop A-port and score very well), ending the trip early.
+    // Falls back to all candidates if the terminal is somehow the only option.
+    let is_terminal = |c: &&Candidate| -> bool {
         matches!(
             home_sector_of(c),
-            Some((_, hx, hy)) if hx == ctx.home.hex_x && hy == ctx.home.hex_y
+            Some((_, hx, hy)) if hx == ctx.terminal.hex_x && hy == ctx.terminal.hex_y
         )
     };
     let candidates_for_search: Vec<&Candidate> = if progress < 0.5 {
-        let filtered: Vec<&Candidate> = candidates.iter().filter(|c| !is_home(c)).collect();
+        let filtered: Vec<&Candidate> = candidates.iter().filter(|c| !is_terminal(c)).collect();
         if filtered.is_empty() {
             candidates.iter().collect()
         } else {
@@ -240,32 +247,34 @@ pub fn pick_next<'a>(
         candidates.iter().collect()
     };
 
-    // Forced-home override. At or past target, if home itself is reachable,
-    // take it regardless of score. v1 is in-sector, so we match purely on
-    // hex coordinates.
+    // Forced-terminal override. At or past target, if the finish world
+    // (destination, or home when none is set) is reachable, take it
+    // regardless of score. v1 is in-sector, so we match purely on hex
+    // coordinates.
     if progress >= 1.0 {
         for c in candidates {
             if let Some((_, hx, hy)) = home_sector_of(c)
-                && hx == ctx.home.hex_x
-                && hy == ctx.home.hex_y
+                && hx == ctx.terminal.hex_x
+                && hy == ctx.terminal.hex_y
             {
                 return Some(c);
             }
         }
     }
 
-    // Head-home mode. Past `HEAD_HOME_THRESHOLD` of trip progress, the
+    // Head-for-finish mode. Past `HEAD_HOME_THRESHOLD` of trip progress, the
     // trade-value score (which can be in the tens of millions) drowns out
-    // the home-bias penalty, so we override it entirely: pick the candidate
-    // with the smallest hex distance to home, breaking ties by score.
+    // the terminal-bias penalty, so we override it entirely: pick the
+    // candidate with the smallest hex distance to the terminal, breaking ties
+    // by score.
     if progress >= HEAD_HOME_THRESHOLD
-        && let Some(home_coords) = sector_hex_of(ctx.home)
+        && let Some(term_coords) = sector_hex_of(ctx.terminal)
     {
         return candidates
             .iter()
             .filter_map(|c| {
                 c.world.coordinates.map(|(x, y)| {
-                    let dh = calculate_hex_distance(x, y, home_coords.0, home_coords.1);
+                    let dh = calculate_hex_distance(x, y, term_coords.0, term_coords.1);
                     (c, dh)
                 })
             })
@@ -279,8 +288,8 @@ pub fn pick_next<'a>(
             .map(|(c, _)| c);
     }
 
-    // Normal mode: pick highest score among non-home candidates (in the
-    // first half of the trip) or all candidates (in the second half).
+    // Normal mode: pick highest score among candidates excluding the terminal
+    // (in the first half of the trip) or all candidates (in the second half).
     candidates_for_search.into_iter().max_by(|a, b| {
         let sa = score_candidate(a, market, ctx);
         let sb = score_candidate(b, market, ctx);
@@ -371,9 +380,9 @@ mod tests {
         }
     }
 
-    fn ctx<'a>(home: &'a WorldRef, history: &'a [WorldRef]) -> RouteContext<'a> {
+    fn ctx<'a>(terminal: &'a WorldRef, history: &'a [WorldRef]) -> RouteContext<'a> {
         RouteContext {
-            home,
+            terminal,
             current_date: Date::new(0, 1105),
             start_date: Date::new(0, 1105),
             target_date: Date::new(100, 1105),
@@ -741,6 +750,60 @@ mod tests {
         let cands = [great_far, mediocre_near];
         let chosen = pick_next(&cands, &market, &c).unwrap();
         assert_eq!(chosen.world.name, "Near");
+    }
+
+    #[test]
+    fn head_for_finish_spirals_to_destination_not_home() {
+        // With a destination set (terminal at (5,0), distinct from the (0,0)
+        // start), past the head-home threshold the planner must spiral toward
+        // the *destination*, not back toward the origin. A great trade world
+        // sitting at the origin must lose to a mediocre one at the destination.
+        let dest_ref = mk_world_ref("Dest", "A788899-A", 5, 0);
+        let great_at_origin = Candidate {
+            world: mk_world("Great", "A999999-F", 0, 0),
+            distance: 2,
+            allegiance: None,
+            gas_giants: 0,
+        };
+        let mediocre_at_dest = Candidate {
+            world: mk_world("AtDest", "E555555-5", 5, 0),
+            distance: 2,
+            allegiance: None,
+            gas_giants: 0,
+        };
+        let market = AvailableGoodsTable::default();
+        let mut c = ctx(&dest_ref, &[]); // terminal = destination (5,0)
+        c.current_date = Date::new(80, 1105); // 80% progress, past 0.75
+
+        let cands = [great_at_origin, mediocre_at_dest];
+        let chosen = pick_next(&cands, &market, &c).unwrap();
+        assert_eq!(chosen.world.name, "AtDest");
+    }
+
+    #[test]
+    fn destination_excluded_in_first_half() {
+        // A one-way run to a destination must not end early by arriving at the
+        // destination in the first half — even if the destination scores best.
+        let dest_ref = mk_world_ref("Dest", "A999999-F", 5, 5);
+        let dest = Candidate {
+            world: mk_world("Dest", "A999999-F", 5, 5),
+            distance: 1,
+            allegiance: None,
+            gas_giants: 0,
+        };
+        let other = Candidate {
+            world: mk_world("Other", "C555555-7", 6, 5),
+            distance: 1,
+            allegiance: None,
+            gas_giants: 0,
+        };
+        let market = AvailableGoodsTable::default();
+        let mut c = ctx(&dest_ref, &[]);
+        c.current_date = Date::new(10, 1105); // ~10% progress
+
+        let cands = [dest, other];
+        let chosen = pick_next(&cands, &market, &c).unwrap();
+        assert_eq!(chosen.world.name, "Other");
     }
 
     #[test]

--- a/src/simulator/route.rs
+++ b/src/simulator/route.rs
@@ -61,6 +61,14 @@ pub struct RouteContext<'a> {
     pub fuel_cost_per_parsec: i64,
     /// Recently visited worlds, **most recent first**.
     pub history: &'a [WorldRef],
+    /// When `true`, the `terminal` is a distinct destination (a one-way run),
+    /// not the home world of a round trip. The planner then steers toward the
+    /// terminal from the very first hop: no first-half exclusion (arriving
+    /// early is fine) and a steady directional pull (`ROUTE_W_TERMINAL_DIRECT`)
+    /// so every stop makes net progress toward the destination. `false` → the
+    /// classic round trip: explore first, then lean home after the halfway
+    /// point via `ROUTE_W_HOME_BIAS`.
+    pub direct_run: bool,
 }
 
 // === Scoring weights ============================================================
@@ -97,6 +105,16 @@ pub const ROUTE_W_FOREIGN_EMPIRE: f64 = 10_000_000.0;
 /// the 50–75% window. Past `HEAD_HOME_THRESHOLD` the planner switches to
 /// a hard "minimize distance to home" mode (see `pick_next`).
 pub const ROUTE_W_HOME_BIAS: f64 = 50_000.0;
+
+/// Directional pull toward the terminal on a **direct run** (a one-way trip
+/// to a distinct destination — see `RouteContext::direct_run`). Applied per
+/// hex of remaining distance to the terminal, from the very first hop, so
+/// every stop makes net progress toward the destination. Sized to reliably
+/// out-steer port/population bonuses (a few hexes of progress ≈ a port-A
+/// bonus) while still yielding to a genuinely outsized on-the-way trade — the
+/// ship trades opportunistically but always advances, arriving early rather
+/// than backtracking. Round trips use `ROUTE_W_HOME_BIAS` instead.
+pub const ROUTE_W_TERMINAL_DIRECT: f64 = 200_000.0;
 
 /// Trip-progress fraction at which the planner abandons trade-value
 /// optimization and starts spiralling home. Past this threshold,
@@ -152,22 +170,30 @@ pub fn score_candidate(
         score -= ROUTE_W_HISTORY / recency;
     }
 
-    // 6) Terminal bias. Past 50% of the trip, push toward the finish world
-    //    (the destination when set, else home).
-    let total = ctx.start_date.days_until(ctx.target_date) as f64;
-    let elapsed = ctx.start_date.days_until(ctx.current_date) as f64;
-    if total > 0.0 {
-        let progress = elapsed / total;
-        if progress > 0.5
-            && let (Some(cand_coords), Some(term_coords)) =
-                (candidate.world.coordinates, sector_hex_of(ctx.terminal))
-        {
-            let dist_term =
-                calculate_hex_distance(cand_coords.0, cand_coords.1, term_coords.0, term_coords.1)
-                    as f64;
-            // Linear ramp: 0 at progress=0.5, full at progress>=1.0.
-            let ramp = ((progress - 0.5) / 0.5).clamp(0.0, 1.0);
-            score -= dist_term * ROUTE_W_HOME_BIAS * ramp;
+    // 6) Terminal bias — pull toward the finish world (the destination when
+    //    set, else home). On a direct run to a distinct destination we steer
+    //    from the very first hop with a steady, stronger pull so every stop
+    //    makes net progress; on a round trip we explore first and lean home
+    //    only after the halfway point.
+    if let (Some(cand_coords), Some(term_coords)) =
+        (candidate.world.coordinates, sector_hex_of(ctx.terminal))
+    {
+        let dist_term =
+            calculate_hex_distance(cand_coords.0, cand_coords.1, term_coords.0, term_coords.1)
+                as f64;
+        if ctx.direct_run {
+            score -= dist_term * ROUTE_W_TERMINAL_DIRECT;
+        } else {
+            let total = ctx.start_date.days_until(ctx.target_date) as f64;
+            let elapsed = ctx.start_date.days_until(ctx.current_date) as f64;
+            if total > 0.0 {
+                let progress = elapsed / total;
+                if progress > 0.5 {
+                    // Linear ramp: 0 at progress=0.5, full at progress>=1.0.
+                    let ramp = ((progress - 0.5) / 0.5).clamp(0.0, 1.0);
+                    score -= dist_term * ROUTE_W_HOME_BIAS * ramp;
+                }
+            }
         }
     }
 
@@ -225,10 +251,12 @@ pub fn pick_next<'a>(
     let elapsed = ctx.start_date.days_until(ctx.current_date) as f64;
     let progress = if total > 0.0 { elapsed / total } else { 0.0 };
 
-    // Exclude the terminal from the candidate pool while we're still in the
-    // first half of the trip — otherwise the planner heads for the finish
-    // immediately on the first or second hop (home/destination worlds are
-    // typically high-pop A-port and score very well), ending the trip early.
+    // On a round trip, exclude the terminal (home) from the candidate pool
+    // while we're still in the first half — otherwise the planner heads home
+    // immediately on the first or second hop (home is typically high-pop
+    // A-port and scores very well), ending the trip early. On a direct run to
+    // a distinct destination we skip this: arriving early is fine, and the
+    // directional pull in `score_candidate` steers us there steadily.
     // Falls back to all candidates if the terminal is somehow the only option.
     let is_terminal = |c: &&Candidate| -> bool {
         matches!(
@@ -236,7 +264,7 @@ pub fn pick_next<'a>(
             Some((_, hx, hy)) if hx == ctx.terminal.hex_x && hy == ctx.terminal.hex_y
         )
     };
-    let candidates_for_search: Vec<&Candidate> = if progress < 0.5 {
+    let candidates_for_search: Vec<&Candidate> = if progress < 0.5 && !ctx.direct_run {
         let filtered: Vec<&Candidate> = candidates.iter().filter(|c| !is_terminal(c)).collect();
         if filtered.is_empty() {
             candidates.iter().collect()
@@ -389,6 +417,7 @@ mod tests {
             jump: 2,
             fuel_cost_per_parsec: 10_000,
             history,
+            direct_run: false,
         }
     }
 
@@ -781,9 +810,37 @@ mod tests {
     }
 
     #[test]
-    fn destination_excluded_in_first_half() {
-        // A one-way run to a destination must not end early by arriving at the
-        // destination in the first half — even if the destination scores best.
+    fn terminal_excluded_in_first_half_on_round_trip() {
+        // On a round trip (no destination), the planner must not end early by
+        // arriving home in the first half — even if home scores best. Home is
+        // excluded from the first-half candidate pool.
+        let home_ref = mk_world_ref("Home", "A999999-F", 5, 5);
+        let home = Candidate {
+            world: mk_world("Home", "A999999-F", 5, 5),
+            distance: 1,
+            allegiance: None,
+            gas_giants: 0,
+        };
+        let other = Candidate {
+            world: mk_world("Other", "C555555-7", 6, 5),
+            distance: 1,
+            allegiance: None,
+            gas_giants: 0,
+        };
+        let market = AvailableGoodsTable::default();
+        let mut c = ctx(&home_ref, &[]); // direct_run = false (round trip)
+        c.current_date = Date::new(10, 1105); // ~10% progress
+
+        let cands = [home, other];
+        let chosen = pick_next(&cands, &market, &c).unwrap();
+        assert_eq!(chosen.world.name, "Other");
+    }
+
+    #[test]
+    fn direct_run_does_not_exclude_terminal_early() {
+        // On a direct run to a distinct destination, arriving early is fine:
+        // the destination is NOT excluded in the first half, and when it's the
+        // best-scoring option it wins (contrast the round-trip test above).
         let dest_ref = mk_world_ref("Dest", "A999999-F", 5, 5);
         let dest = Candidate {
             world: mk_world("Dest", "A999999-F", 5, 5),
@@ -800,10 +857,55 @@ mod tests {
         let market = AvailableGoodsTable::default();
         let mut c = ctx(&dest_ref, &[]);
         c.current_date = Date::new(10, 1105); // ~10% progress
+        c.direct_run = true;
 
         let cands = [dest, other];
         let chosen = pick_next(&cands, &market, &c).unwrap();
-        assert_eq!(chosen.world.name, "Other");
+        assert_eq!(chosen.world.name, "Dest");
+    }
+
+    #[test]
+    fn direct_run_steers_toward_the_destination_from_the_start() {
+        // Early in the trip, a direct run steers toward the destination: of two
+        // equal-jump forward options (neither the destination itself), the one
+        // closer to the destination wins on the directional pull — even against
+        // a port-A advantage on the farther one. A round trip at the same early
+        // point has no such pull, so the port-A world wins there instead.
+        let dest_ref = mk_world_ref("Dest", "A788899-A", 6, 0);
+        let mk_cands = || {
+            [
+                // Farther from the destination (4 hexes) but a nicer port.
+                Candidate {
+                    world: mk_world("Away", "A555555-5", 2, 0),
+                    distance: 1,
+                    allegiance: None,
+                    gas_giants: 0,
+                },
+                // Closer to the destination (1 hex), plainer port.
+                Candidate {
+                    world: mk_world("Toward", "E555555-5", 5, 0),
+                    distance: 1,
+                    allegiance: None,
+                    gas_giants: 0,
+                },
+            ]
+        };
+        let market = AvailableGoodsTable::default();
+
+        // Direct run, 10% in: the directional pull picks the closer world.
+        let mut c_direct = ctx(&dest_ref, &[]);
+        c_direct.current_date = Date::new(10, 1105);
+        c_direct.direct_run = true;
+        let direct_cands = mk_cands();
+        let direct = pick_next(&direct_cands, &market, &c_direct).unwrap();
+        assert_eq!(direct.world.name, "Toward");
+
+        // Round trip, same early point: no directional pull yet → port-A wins.
+        let mut c_round = ctx(&dest_ref, &[]);
+        c_round.current_date = Date::new(10, 1105);
+        let round_cands = mk_cands();
+        let round = pick_next(&round_cands, &market, &c_round).unwrap();
+        assert_eq!(round.world.name, "Away");
     }
 
     #[test]

--- a/src/simulator/types.rs
+++ b/src/simulator/types.rs
@@ -339,11 +339,12 @@ pub struct SimulationParams {
     /// with no safe fencing / prize bank / lie-low there.
     #[serde(default = "default_true")]
     pub home_is_haven: bool,
-    /// Optional cruise destination (Piracy mode only). When set, the pirate
-    /// cruise makes for this world to finish instead of looping back to the
-    /// hideout; the hideout (`home_world`) still serves as the mid-cruise
-    /// fence, prize bank, and lie-low sanctuary. `None` → round trip back to
-    /// `home_world` (the original behaviour). Ignored in Trade mode.
+    /// Optional destination (both modes). When set, the trip makes for this
+    /// world to finish instead of looping back home: the trade run sells out
+    /// its hold and settles there, and the pirate cruise ends there (the
+    /// hideout still serves as the mid-cruise fence, prize bank, and lie-low
+    /// sanctuary). `None` → round trip back to `home_world` (the original
+    /// behaviour).
     #[serde(default)]
     pub destination: Option<WorldRef>,
     /// Whether the destination is also a **haven** (see `home_is_haven`).

--- a/src/simulator/world_fetch.rs
+++ b/src/simulator/world_fetch.rs
@@ -1,34 +1,37 @@
 //! Server-side TravellerMap client for the simulator.
 //!
-//! In v1 the simulator stays inside one sector. To build the candidate
-//! list for a single jump we enumerate every hex within `jump` parsecs
-//! of the current location, fetch each from `https://travellermap.com/`,
-//! and turn the populated hexes into [`Candidate`]s. Empty hexes (404
-//! responses) are cached as `None` so a re-visit doesn't pay the
-//! network cost again.
+//! Candidate lookups use the `/api/jumpworlds` endpoint, which returns
+//! every world within `jump` parsecs of a hex **including worlds in
+//! adjacent sectors** — so a route can cross sector boundaries. Each
+//! returned world carries its own sector name, sector-local hex, and
+//! TravellerMap's absolute `WorldX`/`WorldY` coordinates.
+//!
+//! ## Absolute hex coordinates
+//!
+//! Cross-sector distance math needs one global grid. We use
+//! `abs = (sx*32 + hx, sy*40 + hy)`, where `(sx, sy)` are the sector
+//! offsets from `/api/coordinates`. Because the column shift `sx*32` is
+//! always even, column parity is preserved, so `calculate_hex_distance`
+//! (odd-q offset) stays exact across sector seams. TravellerMap's own
+//! `WorldX`/`WorldY` relate to this grid by a fixed translation:
+//! `abs = (WorldX + 1, WorldY + 40)` — verified against the live API
+//! (Regina SM 1910 → WorldX/Y (-110, -70) → abs (-109, -30)).
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use futures_util::future::join_all;
 use serde::Deserialize;
-use tokio::sync::Semaphore;
 
 use crate::simulator::route::Candidate;
 use crate::systems::world::{Facility, World};
 use crate::trade::ZoneClassification;
 use crate::util::calculate_hex_distance;
 
-/// Sector-relative hex column range. TravellerMap subsectors are 8x10 each
-/// and a sector is 4x4 subsectors, giving 32 columns and 40 rows.
-const SECTOR_HEX_X_RANGE: std::ops::RangeInclusive<i32> = 1..=32;
-/// Sector-relative hex row range. See [`SECTOR_HEX_X_RANGE`].
-const SECTOR_HEX_Y_RANGE: std::ops::RangeInclusive<i32> = 1..=40;
-
-/// Max number of concurrent TravellerMap fetches. The public service
-/// resets connections aggressively when we hammer it with > ~10
-/// parallel requests, so we throttle hard.
-const MAX_CONCURRENT_FETCHES: usize = 4;
+/// Attempts for the jumpworlds / coordinates calls before giving up. A
+/// failure mid-run aborts the whole simulation, so we absorb transient
+/// TravellerMap hiccups with a couple of retries.
+const MAX_FETCH_ATTEMPTS: usize = 3;
+/// Pause between retry attempts.
+const RETRY_DELAY_MS: u64 = 500;
 
 /// Errors fetching world data from TravellerMap.
 #[derive(Debug, thiserror::Error)]
@@ -44,11 +47,15 @@ pub enum FetchError {
     Malformed(String),
 }
 
-/// One world entry from the TravellerMap `/data/{sector}/{hex}` endpoint.
-///
-/// We keep our own deserialize struct here (instead of reusing the one
-/// in `components/traveller_map.rs`) because that one is wired to
-/// `wasm-bindgen` and lives in a frontend module agent 3 may be touching.
+/// Absolute hex from a sector offset `(sx, sy)` and a sector-local hex.
+/// See the module docs for why this grid (and not raw `WorldX`/`WorldY`)
+/// is the simulator's canonical coordinate space.
+pub fn absolute_hex(offset: (i32, i32), hex: (i32, i32)) -> (i32, i32) {
+    (offset.0 * 32 + hex.0, offset.1 * 40 + hex.1)
+}
+
+/// One world entry from the TravellerMap `/data/{sector}/{hex}` or
+/// `/api/jumpworlds` endpoints (same schema).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct WorldEntry {
@@ -68,15 +75,34 @@ struct WorldEntry {
     /// `"D"` (depot). Mapped onto the world's facilities.
     #[serde(default)]
     bases: Option<String>,
+    /// The world's own sector name (jumpworlds fills this; a neighbourhood
+    /// near a boundary spans sectors).
+    #[serde(default)]
+    sector: Option<String>,
+    /// Sector-local hex, e.g. `"1910"`.
+    #[serde(default)]
+    hex: Option<String>,
+    /// TravellerMap absolute world coordinates. `abs = (world_x + 1,
+    /// world_y + 40)` — see module docs.
+    #[serde(default)]
+    world_x: Option<i32>,
+    #[serde(default)]
+    world_y: Option<i32>,
 }
 
-/// Wrapper for `/data/{sector}/{hex}` responses. The endpoint always
-/// returns a `Worlds` array — usually a single element, sometimes empty
-/// (treated as a 404).
+/// Wrapper for world-list responses. The endpoints always return a
+/// `Worlds` array — sometimes empty (treated as a 404).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct WorldsEnvelope {
     worlds: Vec<WorldEntry>,
+}
+
+/// `/api/coordinates?sector=…` response (we only need the sector offsets).
+#[derive(Debug, Deserialize)]
+struct CoordinatesResponse {
+    sx: i32,
+    sy: i32,
 }
 
 /// One cached lookup result: a populated `World`, its TravellerMap
@@ -87,11 +113,16 @@ struct WorldsEnvelope {
 /// `World`'s facilities, since `World` already models those.)
 type CachedWorld = (World, Option<String>, u8);
 
-/// Cache of TravellerMap world data lookups, keyed by
-/// `(sector_name, hex_x, hex_y)`. `None` = empty hex (404 from
-/// TravellerMap), so subsequent fetches return immediately.
+/// Cache of TravellerMap lookups: single-hex world data, per-sector
+/// offsets, and whole jump-neighbourhood candidate lists.
 pub struct WorldCache {
     inner: HashMap<(String, i32, i32), Option<CachedWorld>>,
+    /// Sector name → `(sx, sy)` offsets from `/api/coordinates`.
+    sector_offsets: HashMap<String, (i32, i32)>,
+    /// `(sector, hex_x, hex_y, jump)` → candidate list. The universe is
+    /// static, so revisiting a hex re-serves the same neighbourhood
+    /// without another network round-trip.
+    jump_cache: HashMap<(String, i32, i32, i32), Vec<Candidate>>,
     client: reqwest::Client,
 }
 
@@ -115,6 +146,8 @@ impl WorldCache {
             .expect("reqwest client must build");
         Self {
             inner: HashMap::new(),
+            sector_offsets: HashMap::new(),
+            jump_cache: HashMap::new(),
             client,
         }
     }
@@ -138,100 +171,190 @@ impl WorldCache {
         Ok(entry)
     }
 
-    /// Find every world within `jump` parsecs of the given hex (excluding
-    /// the hex itself). All fetches run in parallel; empty hexes and any
-    /// individual fetch failures are skipped silently — we'd rather make
-    /// progress on the run than abort because one neighbouring hex
-    /// hiccupped.
+    /// The `(sx, sy)` offsets of a sector, from `/api/coordinates`.
+    /// Cached per sector name — a run touches at most a handful.
+    pub async fn sector_offset(&mut self, sector: &str) -> Result<(i32, i32), FetchError> {
+        if let Some(&off) = self.sector_offsets.get(sector) {
+            return Ok(off);
+        }
+        let url = format!(
+            "{}/api/coordinates?sector={}",
+            crate::util::travellermap_base_url(),
+            urlencode(sector)
+        );
+        let body = get_with_retries(&self.client, &url).await?;
+        let coords: CoordinatesResponse = serde_json::from_str(&body)
+            .map_err(|e| FetchError::Malformed(format!("{}: {}", url, e)))?;
+        self.sector_offsets
+            .insert(sector.to_string(), (coords.sx, coords.sy));
+        Ok((coords.sx, coords.sy))
+    }
+
+    /// Every world within `jump` parsecs of the given hex (excluding the
+    /// hex itself), **across sector boundaries**. One `/api/jumpworlds`
+    /// call; individual malformed entries are skipped so a single odd
+    /// world can't sink the run.
     pub async fn candidates_within(
         &mut self,
         sector: &str,
         from_hex: (i32, i32),
         jump: i32,
     ) -> Result<Vec<Candidate>, FetchError> {
-        // Build the list of hexes worth fetching.
-        let mut targets: Vec<(i32, i32, i32)> = Vec::new();
-        for x in SECTOR_HEX_X_RANGE {
-            for y in SECTOR_HEX_Y_RANGE {
-                if (x, y) == from_hex {
-                    continue;
-                }
-                let d = calculate_hex_distance(from_hex.0, from_hex.1, x, y);
-                if d > 0 && d <= jump {
-                    targets.push((x, y, d));
-                }
-            }
+        let key = (sector.to_string(), from_hex.0, from_hex.1, jump);
+        if let Some(cached) = self.jump_cache.get(&key) {
+            return Ok(cached.clone());
         }
 
-        // Split into already-cached hits and ones that need fetching.
+        let origin_abs = absolute_hex(self.sector_offset(sector).await?, from_hex);
+        let url = format!(
+            "{}/api/jumpworlds?sector={}&hex={:02}{:02}&jump={}",
+            crate::util::travellermap_base_url(),
+            urlencode(sector),
+            from_hex.0,
+            from_hex.1,
+            jump
+        );
+        log::trace!("world_fetch: GET {}", url);
+        let body = get_with_retries(&self.client, &url).await?;
+        let envelope: WorldsEnvelope = serde_json::from_str(&body)
+            .map_err(|e| FetchError::Malformed(format!("{}: {}", url, e)))?;
+
         let mut candidates: Vec<Candidate> = Vec::new();
-        let mut to_fetch: Vec<(i32, i32, i32)> = Vec::new();
-        for (x, y, d) in targets {
-            let key = (sector.to_string(), x, y);
-            if let Some(cached) = self.inner.get(&key) {
-                if let Some((world, allegiance, gas_giants)) = cached {
-                    candidates.push(Candidate {
-                        world: world.clone(),
-                        distance: d,
-                        allegiance: allegiance.clone(),
-                        gas_giants: *gas_giants,
-                    });
-                }
-            } else {
-                to_fetch.push((x, y, d));
+        for entry in envelope.worlds {
+            let entry_sector = entry
+                .sector
+                .clone()
+                .unwrap_or_else(|| sector.to_string());
+            let Some(hex) = entry.hex.as_deref().and_then(parse_hex) else {
+                log::debug!(
+                    "world_fetch: skipping {:?} in {} — missing/bad hex {:?}",
+                    entry.name,
+                    entry_sector,
+                    entry.hex
+                );
+                continue;
+            };
+            // Absolute coords: prefer the entry's own WorldX/WorldY;
+            // fall back to the sector-offset formula.
+            let abs = match (entry.world_x, entry.world_y) {
+                (Some(wx), Some(wy)) => (wx + 1, wy + 40),
+                _ => absolute_hex(self.sector_offset(&entry_sector).await?, hex),
+            };
+            let d = calculate_hex_distance(origin_abs.0, origin_abs.1, abs.0, abs.1);
+            if d == 0 || d > jump {
+                // The origin world itself, or (belt & braces) something
+                // outside jump range.
+                continue;
             }
-        }
-
-        // Fetch the rest in parallel, throttled by a semaphore to avoid
-        // overwhelming TravellerMap (which resets connections under
-        // load).
-        let client = self.client.clone();
-        let sector_owned = sector.to_string();
-        let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_FETCHES));
-        let futs = to_fetch.iter().map(|&(x, y, _d)| {
-            let client = client.clone();
-            let sector = sector_owned.clone();
-            let sem = semaphore.clone();
-            async move {
-                let _permit = sem.acquire_owned().await.ok();
-                let res = fetch_one(&client, &sector, x, y).await;
-                (x, y, res)
-            }
-        });
-        let results = join_all(futs).await;
-
-        for ((x, y, d), (rx, ry, res)) in to_fetch.iter().zip(results) {
-            debug_assert_eq!((*x, *y), (rx, ry));
-            let key = (sector.to_string(), *x, *y);
-            match res {
-                Ok(Some((world, allegiance, gas_giants))) => {
-                    self.inner
-                        .insert(key, Some((world.clone(), allegiance.clone(), gas_giants)));
+            match build_world(&entry, hex) {
+                Ok((world, gas_giants)) => {
+                    // Keep the single-hex cache warm too.
+                    self.inner.insert(
+                        (entry_sector.clone(), hex.0, hex.1),
+                        Some((world.clone(), entry.allegiance.clone(), gas_giants)),
+                    );
                     candidates.push(Candidate {
                         world,
-                        distance: *d,
-                        allegiance,
+                        sector: entry_sector,
+                        abs,
+                        distance: d,
+                        allegiance: entry.allegiance,
                         gas_giants,
                     });
                 }
-                Ok(None) => {
-                    self.inner.insert(key, None);
-                }
                 Err(e) => {
                     log::debug!(
-                        "world_fetch: skipping hex {:02}{:02} in {} ({:?})",
-                        x,
-                        y,
-                        sector,
+                        "world_fetch: skipping {} {:02}{:02} in {} ({:?})",
+                        entry.name,
+                        hex.0,
+                        hex.1,
+                        entry_sector,
                         e
                     );
-                    // Don't cache; transient errors might recover.
                 }
             }
         }
 
+        self.jump_cache.insert(key, candidates.clone());
         Ok(candidates)
     }
+}
+
+/// GET a URL, retrying transient failures a couple of times. Returns the
+/// response body on the first 2xx.
+async fn get_with_retries(client: &reqwest::Client, url: &str) -> Result<String, FetchError> {
+    let mut last_err: Option<FetchError> = None;
+    for attempt in 1..=MAX_FETCH_ATTEMPTS {
+        match client.get(url).send().await {
+            Ok(resp) if resp.status().is_success() => match resp.text().await {
+                Ok(body) => return Ok(body),
+                Err(e) => last_err = Some(e.into()),
+            },
+            Ok(resp) => {
+                last_err = Some(FetchError::Malformed(format!(
+                    "{} returned status {}",
+                    url,
+                    resp.status()
+                )));
+            }
+            Err(e) => last_err = Some(e.into()),
+        }
+        if attempt < MAX_FETCH_ATTEMPTS {
+            log::debug!("world_fetch: retrying {} (attempt {})", url, attempt);
+            tokio::time::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS)).await;
+        }
+    }
+    Err(last_err.unwrap_or_else(|| FetchError::Malformed(format!("{}: no attempts made", url))))
+}
+
+/// Parse a TravellerMap 4-digit hex string (`"1910"`) into `(x, y)`.
+fn parse_hex(hex: &str) -> Option<(i32, i32)> {
+    if hex.len() != 4 {
+        return None;
+    }
+    let x = hex[0..2].parse::<i32>().ok()?;
+    let y = hex[2..4].parse::<i32>().ok()?;
+    Some((x, y))
+}
+
+/// Build a populated `World` (plus gas-giant count) from a fetched entry.
+/// `coords` are the sector-local hex, stored on `World.coordinates` to
+/// match the wire-format `WorldRef` the frontend renders.
+fn build_world(entry: &WorldEntry, coords: (i32, i32)) -> Result<(World, u8), FetchError> {
+    let mut world = World::from_uwp(&entry.name, &entry.uwp, false, true)
+        .map_err(|e| FetchError::InvalidUwp(format!("{}: {}", entry.uwp, e)))?;
+    world.gen_trade_classes();
+    world.coordinates = Some(coords);
+    world.travel_zone = match entry.zone.as_deref() {
+        Some("A") => ZoneClassification::Amber,
+        Some("R") => ZoneClassification::Red,
+        _ => ZoneClassification::Green,
+    };
+
+    // Map base codes onto the world's facilities (used by the pirate
+    // simulator's encounter modifiers).
+    if let Some(bases) = entry.bases.as_deref() {
+        let mut facilities = Vec::new();
+        if bases.contains('N') || bases.contains('A') {
+            facilities.push(Facility::Naval);
+        }
+        if bases.contains('S') || bases.contains('A') {
+            facilities.push(Facility::Scout);
+        }
+        if !facilities.is_empty() {
+            world.set_facilities(facilities);
+        }
+    }
+
+    // Gas giants are the third digit of the PBG code.
+    let gas_giants = entry
+        .pbg
+        .as_deref()
+        .and_then(|p| p.chars().nth(2))
+        .and_then(|c| c.to_digit(16))
+        .unwrap_or(0) as u8;
+
+    Ok((world, gas_giants))
 }
 
 /// Fetch one hex from TravellerMap. Returns `Ok(None)` on 404 / empty
@@ -277,39 +400,7 @@ async fn fetch_one(
         None => return Ok(None),
     };
 
-    let mut world = World::from_uwp(&entry.name, &entry.uwp, false, true)
-        .map_err(|e| FetchError::InvalidUwp(format!("{}: {}", entry.uwp, e)))?;
-    world.gen_trade_classes();
-    world.coordinates = Some((hex_x, hex_y));
-    world.travel_zone = match entry.zone.as_deref() {
-        Some("A") => ZoneClassification::Amber,
-        Some("R") => ZoneClassification::Red,
-        _ => ZoneClassification::Green,
-    };
-
-    // Map base codes onto the world's facilities (used by the pirate
-    // simulator's encounter modifiers).
-    if let Some(bases) = entry.bases.as_deref() {
-        let mut facilities = Vec::new();
-        if bases.contains('N') || bases.contains('A') {
-            facilities.push(Facility::Naval);
-        }
-        if bases.contains('S') || bases.contains('A') {
-            facilities.push(Facility::Scout);
-        }
-        if !facilities.is_empty() {
-            world.set_facilities(facilities);
-        }
-    }
-
-    // Gas giants are the third digit of the PBG code.
-    let gas_giants = entry
-        .pbg
-        .as_deref()
-        .and_then(|p| p.chars().nth(2))
-        .and_then(|c| c.to_digit(16))
-        .unwrap_or(0) as u8;
-
+    let (world, gas_giants) = build_world(&entry, (hex_x, hex_y))?;
     Ok(Some((world, entry.allegiance, gas_giants)))
 }
 
@@ -344,6 +435,34 @@ mod tests {
         assert_eq!(urlencode("a/b"), "a%2Fb");
     }
 
+    #[test]
+    fn parse_hex_valid_and_invalid() {
+        assert_eq!(parse_hex("1910"), Some((19, 10)));
+        assert_eq!(parse_hex("0140"), Some((1, 40)));
+        assert_eq!(parse_hex("19"), None);
+        assert_eq!(parse_hex("abcd"), None);
+    }
+
+    #[test]
+    fn absolute_hex_matches_travellermap_worldxy() {
+        // Regina: Spinward Marches (sx -4, sy -1) hex 1910. TravellerMap
+        // reports WorldX/WorldY = (-110, -70); our grid is that plus
+        // (1, 40) — verified against the live /api/coordinates endpoint.
+        assert_eq!(absolute_hex((-4, -1), (19, 10)), (-109, -30));
+        // Borite: Trojan Reach (sx -4, sy 0) hex 2219; WorldX/Y (-107, -21).
+        assert_eq!(absolute_hex((-4, 0), (22, 19)), (-106, 19));
+    }
+
+    #[test]
+    fn absolute_hex_distance_across_sector_seam() {
+        // Aramis (Spinward Marches 2540, bottom row) and Labora (Trojan
+        // Reach 2501, top row) sit on adjacent rows across the seam.
+        let aramis = absolute_hex((-4, -1), (25, 40));
+        let labora = absolute_hex((-4, 0), (25, 1));
+        let d = calculate_hex_distance(aramis.0, aramis.1, labora.0, labora.1);
+        assert_eq!(d, 1, "adjacent rows across the seam are 1 apart");
+    }
+
     #[tokio::test]
     #[ignore]
     async fn fetch_one_regina() {
@@ -368,5 +487,43 @@ mod tests {
             allegiance
         );
         eprintln!("entry: {:?}", entry);
+    }
+
+    /// Live check that `/api/jumpworlds` crosses sector boundaries and our
+    /// absolute-coordinate math agrees with TravellerMap's `WorldX`/`WorldY`.
+    #[tokio::test]
+    #[ignore]
+    async fn jumpworlds_crosses_sector_boundary() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let mut cache = WorldCache::new();
+        // Trojan Reach 2402 is near the coreward edge; jump 4 reaches the
+        // Spinward Marches bottom rows (Aramis, Thisbe, …).
+        let candidates = cache
+            .candidates_within("Trojan Reach", (24, 2), 4)
+            .await
+            .expect("jumpworlds fetch should succeed");
+        assert!(!candidates.is_empty());
+        let cross: Vec<&Candidate> = candidates
+            .iter()
+            .filter(|c| c.sector == "Spinward Marches")
+            .collect();
+        assert!(
+            !cross.is_empty(),
+            "expected Spinward Marches worlds within jump-4 of Trojan Reach 2402"
+        );
+        for c in &candidates {
+            assert!(
+                c.distance >= 1 && c.distance <= 4,
+                "{} distance {} out of range",
+                c.world.name,
+                c.distance
+            );
+        }
+        // Offsets should agree with the hardcoded map table.
+        assert_eq!(cache.sector_offset("Trojan Reach").await.unwrap(), (-4, 0));
+        assert_eq!(
+            cache.sector_offset("Spinward Marches").await.unwrap(),
+            (-4, -1)
+        );
     }
 }


### PR DESCRIPTION
## Summary

Brings the **trade simulator** in line with the pirate cruise (PR #30) — an optional **destination** the ship makes for instead of a round trip — and then makes destinations actually work at range: **directional routing with guaranteed progress, across sector boundaries**, for both the trade and piracy simulators.

Verified live end-to-end: **Drinax (Trojan Reach 2223) → Regina (Spinward Marches 1910) at Jump-4** — ~54 parsecs, arriving in ~21 strictly-monotonic jumps across the sector seam.

## Commit 1 — destination option (`0e88112`)

- The "Destination (optional)" fieldset shows in both modes (Haven checkbox stays piracy-only); summary shows "Reached <dest>?" for any run with a destination.
- Trade planner + executor gain a `terminal` anchor (destination if set, else home); the trip ends by selling out and settling at the terminal. No wire changes — `destination` was already plumbed.

## Commit 2 — steer from the start (`a13fa07`)

- A set destination makes the trip a **direct run**: no first-half exclusion (arriving early is fine) and a directional pull toward the destination from the first hop, instead of the round trip's explore-then-head-home ramp.

## Commit 3 — cross-sector routing (`82564b8`)

- **Absolute hex coordinates** (`sx*32+hx, sy*40+hy`) become the canonical space for all planner math (both planners). Parity-preserving, so hex distances stay exact across seams. Sector offsets via `/api/coordinates`, cached.
- **`/api/jumpworlds`** replaces the per-hex candidate fetch: one HTTP call per jump (the Regina smoke drops ~20s → <1s), returning worlds in adjacent sectors with their own sector names + absolute coords. 3× retry on transient failures.
- The executor tracks the ship's absolute position; each step's `WorldRef` carries the world's **own** sector, so the route map renders cross-sector paths correctly.
- **Strict-progress filter** on direct runs: only candidates strictly closer to the destination are eligible (full-pool fallback when boxed in). Progress is structural, not a beatable weight — remaining distance decreases every jump, so arrival is guaranteed.
- **Latent bug fixed**: the history revisit penalty never fired in production (empty-string sector comparison), which fueled oscillation loops (Realgar↔Cordillon↔Vume). Now works; regression test added.

## Verification

- 307 lib tests pass; clippy clean on native (`--features backend`) and `wasm32-unknown-unknown`.
- Live smokes: `simulator_smoke_regina` (round-trip regression, unchanged behavior), `jumpworlds_crosses_sector_boundary`, and new `simulator_smoke_drinax_to_regina`.
- Round trips (no destination) are behavior-identical: terminal == home, strict-progress filter off.
- No change to the public `/api/system` surface.

## Note for players

A ~54-pc run takes roughly 1.5 game-years (14+ days/stop, and a Government Complication can eat 2d6 weeks). Set the target date generously or the overflow-abort guard ends the run mid-route by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)