### PR TITLE
Deploy script: abort on failure instead of re-deploying stale :latest

### DIFF
--- a/scripts/push_image.sh
+++ b/scripts/push_image.sh
@@ -1,5 +1,13 @@
 #!/bin/zsh
 
+# Abort on the first failure — most importantly a failed `docker buildx
+# build`. Without this, a build error (e.g. the buildx builder container
+# dying after a laptop sleep) fell through to `gcloud run deploy`, which
+# re-deployed the previous :latest image as a brand-new revision: stale
+# code wearing a successful-deploy costume. Seen in the wild 2026-07-21.
+set -e
+set -o pipefail
+
 # GCS_BUCKET controls the /world endpoint's planet-PNG cache. Without
 # it (or set to "debug"), every /world request regenerates the planet
 # from scratch (~25 s); with it, subsequent calls are served from the


### PR DESCRIPTION
One-liner guard (`set -e` + `pipefail`) for `push_image.sh`.

Without it, a failed `docker buildx build` fell through to `gcloud run deploy`, which re-deployed the previous `:latest` image as a new revision — stale code that reads as a successful deploy. This bit us on 2026-07-21: revisions `worldgen-00111`/`00112` shipped the identical pre-merge digest while `main` had moved ahead, which is why the cross-sector routing "didn't take" on the first two deploys.

The existing `||` fallback on `docker buildx create` and the `if`-guarded probes are unaffected by `set -e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)